### PR TITLE
Add expand, clean, and completions commands to dusk-forge CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add the `dusk-forge` CLI with `new`, `build`, `test`, and `check` commands for contract project scaffolding and workflows.
+- Add `expand`, `clean`, and `completions` commands to the `dusk-forge` CLI.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ syn = { version = "2", features = ["full", "visit"] }
 assert_cmd = "=2.1.1"
 cargo_metadata = "0.19"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 colored = "3"
 predicates = "3"
 tempfile = "=3.10.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 cargo_metadata = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+clap_complete = { workspace = true }
 colored = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/cli/README.md
+++ b/cli/README.md
@@ -42,6 +42,9 @@ cargo run -p dusk-forge-cli -- --help
 - `dusk-forge build [target]`: build WASM artifacts. Targets: `all` (default), `contract`, `data-driver`.
 - `dusk-forge test [-- <cargo-test-args>]`: build contract WASM and run `cargo test --release`.
 - `dusk-forge check`: validate project structure and toolchain.
+- `dusk-forge expand [--data-driver]`: show macro expansion with `cargo-expand`.
+- `dusk-forge clean`: remove `target/contract` and `target/data-driver`.
+- `dusk-forge completions <shell>`: generate shell completions.
 
 ## Common Options
 
@@ -81,6 +84,7 @@ Data-driver builds require:
 Optional tools:
 
 - `wasm-opt` for smaller WASM artifacts
+- `cargo-expand` for the `expand` command
 
 ## Template Notes
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 
 use crate::build_runner::BuildTarget;
 
@@ -49,6 +50,12 @@ pub enum Commands {
     Test(TestArgs),
     /// Validate project structure and toolchain.
     Check(ProjectOptions),
+    /// Show macro-expanded code using cargo-expand.
+    Expand(ExpandArgs),
+    /// Remove contract-specific build artifact directories.
+    Clean(ProjectOptions),
+    /// Generate shell completion scripts.
+    Completions(CompletionsArgs),
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -108,4 +115,60 @@ pub struct TestArgs {
 
     /// Extra args passed through to `cargo test --release`.
     pub cargo_test_args: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct ExpandArgs {
+    #[command(flatten)]
+    pub project: ProjectOptions,
+
+    /// Expand with the data-driver feature.
+    #[arg(long)]
+    pub data_driver: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct CompletionsArgs {
+    /// Shell to generate completions for.
+    #[arg(value_enum)]
+    pub shell: Shell,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use clap::Parser;
+
+    use super::{Cli, Commands};
+
+    #[test]
+    fn parses_expand_command() {
+        let cli = Cli::parse_from(["dusk-forge", "expand", "--data-driver"]);
+
+        match cli.command {
+            Commands::Expand(args) => assert!(args.data_driver),
+            other => panic!("expected expand command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_clean_command() {
+        let cli = Cli::parse_from(["dusk-forge", "clean", "--path", "demo"]);
+
+        match cli.command {
+            Commands::Clean(args) => assert_eq!(args.path, PathBuf::from("demo")),
+            other => panic!("expected clean command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_completions_command() {
+        let cli = Cli::parse_from(["dusk-forge", "completions", "bash"]);
+
+        match cli.command {
+            Commands::Completions(_) => {}
+            other => panic!("expected completions command, got {other:?}"),
+        }
+    }
 }

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+use crate::{
+    cli::ProjectOptions,
+    error::Result,
+    project::{detect, metadata},
+    ui,
+};
+
+pub fn run(args: ProjectOptions) -> Result<()> {
+    let project = metadata::load(&args.path)?;
+    detect::ensure_forge_project(&project.project_dir)?;
+
+    remove_if_exists(&project.contract_target_dir)?;
+    remove_if_exists(&project.data_driver_target_dir)?;
+
+    ui::success("Cleaned target/contract and target/data-driver");
+    Ok(())
+}
+
+fn remove_if_exists(path: &std::path::Path) -> Result<()> {
+    if path.exists() {
+        fs::remove_dir_all(path)?;
+        ui::status(format!("Removed {}", path.display()));
+    } else {
+        ui::status(format!("Skipped {}, not present", path.display()));
+    }
+    Ok(())
+}

--- a/cli/src/commands/completions.rs
+++ b/cli/src/commands/completions.rs
@@ -1,0 +1,16 @@
+use std::io;
+
+use clap::CommandFactory;
+use clap_complete::generate;
+
+use crate::{
+    cli::{Cli, CompletionsArgs},
+    error::Result,
+};
+
+pub fn run(args: CompletionsArgs) -> Result<()> {
+    let mut cmd = Cli::command();
+    let name = cmd.get_name().to_string();
+    generate(args.shell, &mut cmd, name, &mut io::stdout());
+    Ok(())
+}

--- a/cli/src/commands/expand.rs
+++ b/cli/src/commands/expand.rs
@@ -1,0 +1,61 @@
+use std::process::{Command, Stdio};
+
+use crate::{
+    build_runner,
+    cli::ExpandArgs,
+    error::{CliError, Result},
+    project::{detect, metadata},
+    toolchain::{self, WASM_TARGET},
+    tools, ui,
+};
+
+pub fn run(args: ExpandArgs) -> Result<()> {
+    let project = metadata::load(&args.project.path)?;
+    detect::ensure_forge_project(&project.project_dir)?;
+
+    if tools::find_in_path("cargo-expand").is_none() {
+        return Err(CliError::MissingTool {
+            tool: "cargo-expand",
+            hint: "Install with: cargo install cargo-expand",
+        });
+    }
+
+    let feature = if args.data_driver {
+        "data-driver-js"
+    } else {
+        "contract"
+    };
+
+    ui::status(format!("Expanding macros with feature '{feature}'"));
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg(toolchain::cargo_toolchain_arg(&project.project_dir)?)
+        .arg("expand")
+        .arg("--release")
+        .arg("--locked")
+        .arg("--features")
+        .arg(feature)
+        .arg("--target")
+        .arg(WASM_TARGET)
+        .arg("--manifest-path")
+        .arg(&project.manifest_path)
+        .current_dir(&project.project_dir)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .stdin(Stdio::inherit());
+    build_runner::apply_local_forge_overrides(&mut cmd, args.project.verbose);
+
+    if args.project.verbose {
+        eprintln!("Running: {}", ui::format_command(&cmd));
+    }
+
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err(CliError::CommandFailed {
+            program: "cargo expand".to_string(),
+            code: status.code().unwrap_or(1),
+        });
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,4 +1,7 @@
 pub mod build;
 pub mod check;
+pub mod clean;
+pub mod completions;
+pub mod expand;
 pub mod new;
 pub mod test;

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -18,6 +18,12 @@ pub enum CliError {
     #[error("expected a Dusk Forge contract project at {0}")]
     NotAForgeProject(PathBuf),
 
+    #[error("required tool not found: {tool}. {hint}")]
+    MissingTool {
+        tool: &'static str,
+        hint: &'static str,
+    },
+
     #[error("command failed: {program} (exit code {code})")]
     CommandFailed { program: String, code: i32 },
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -27,5 +27,8 @@ fn run() -> Result<()> {
         Commands::Build(args) => commands::build::run(args),
         Commands::Test(args) => commands::test::run(args),
         Commands::Check(args) => commands::check::run(args),
+        Commands::Expand(args) => commands::expand::run(args),
+        Commands::Clean(args) => commands::clean::run(args),
+        Commands::Completions(args) => commands::completions::run(args),
     }
 }

--- a/cli/tests/core_commands.rs
+++ b/cli/tests/core_commands.rs
@@ -1,0 +1,326 @@
+#![cfg(unix)]
+
+use std::{
+    env,
+    ffi::OsString,
+    fs,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+};
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use tempfile::{tempdir, TempDir};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("write executable");
+    let mut permissions = fs::metadata(path).expect("metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("chmod +x");
+}
+
+fn shell_quote(path: &Path) -> String {
+    let escaped = path.to_string_lossy().replace('\'', "'\"'\"'");
+    format!("'{escaped}'")
+}
+
+fn resolve_program(program: &str) -> PathBuf {
+    env::split_paths(&env::var_os("PATH").expect("PATH env var"))
+        .map(|dir| dir.join(program))
+        .find(|candidate| candidate.is_file())
+        .unwrap_or_else(|| panic!("unable to resolve {program} on PATH"))
+}
+
+fn create_project() -> (TempDir, PathBuf) {
+    let tmp = tempdir().expect("tempdir");
+    let project = tmp.path().join("smoke-contract");
+
+    fs::create_dir_all(project.join("src")).expect("create src");
+    fs::create_dir_all(project.join("tests")).expect("create tests");
+
+    let cargo_toml = format!(
+        r#"[package]
+name = "smoke-contract"
+version = "0.1.0"
+edition = "2021"
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+dusk-forge = {{ path = "{}" }}
+
+[features]
+contract = []
+data-driver = []
+data-driver-js = ["data-driver"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[profile.release]
+overflow-checks = true
+"#,
+        repo_root().display()
+    );
+
+    fs::write(project.join("Cargo.toml"), cargo_toml).expect("write Cargo.toml");
+    fs::write(project.join("src/lib.rs"), "pub fn host_only() {}\n").expect("write lib.rs");
+    fs::write(
+        project.join("tests/contract.rs"),
+        "#[test]\nfn smoke() {}\n",
+    )
+    .expect("write test file");
+    fs::write(
+        project.join("rust-toolchain.toml"),
+        "[toolchain]\nchannel = \"nightly-2024-07-30\"\n",
+    )
+    .expect("write rust-toolchain.toml");
+    fs::write(project.join("Cargo.lock"), "").expect("write Cargo.lock");
+
+    (tmp, project)
+}
+
+struct FakeTools {
+    _tmp: TempDir,
+    bin_dir: PathBuf,
+    log_path: PathBuf,
+}
+
+impl FakeTools {
+    fn new() -> Self {
+        let tmp = tempdir().expect("tempdir");
+        let bin_dir = tmp.path().join("bin");
+        fs::create_dir_all(&bin_dir).expect("create bin dir");
+
+        let log_path = tmp.path().join("tool.log");
+        let real_cargo = env::var_os("CARGO")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| resolve_program("cargo"));
+        let real_rustc = resolve_program("rustc");
+
+        let cargo_script = format!(
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+
+toolchain=""
+if [[ "${{1-}}" == +* ]]; then
+  toolchain="$1"
+  shift
+fi
+
+subcmd="${{1-}}"
+if [[ -z "$subcmd" ]]; then
+  exit 1
+fi
+shift || true
+
+case "$subcmd" in
+  metadata|generate-lockfile)
+    if [[ -n "$toolchain" ]]; then
+      exec {real_cargo} "$toolchain" "$subcmd" "$@"
+    else
+      exec {real_cargo} "$subcmd" "$@"
+    fi
+    ;;
+  build)
+    manifest=""
+    feature=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --manifest-path)
+          manifest="$2"
+          shift 2
+          ;;
+        --features)
+          feature="$2"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+
+    crate_name="$(sed -n 's/^name = \"\(.*\)\"$/\1/p' "$manifest" | head -n1)"
+    crate_name="${{crate_name//-/_}}"
+    wasm_path="${{CARGO_TARGET_DIR}}/wasm32-unknown-unknown/release/${{crate_name}}.wasm"
+    mkdir -p "$(dirname "$wasm_path")"
+    printf '%s\n' "$feature" > "$wasm_path"
+    printf 'subcmd=build toolchain=%s feature=%s target_dir=%s manifest=%s\n' \
+      "$toolchain" "$feature" "${{CARGO_TARGET_DIR-}}" "$manifest" >> {log_path}
+    exit 0
+    ;;
+  test)
+    printf 'subcmd=test toolchain=%s args=%s\n' \
+      "$toolchain" "$*" >> {log_path}
+    exit 0
+    ;;
+  *)
+    if [[ -n "$toolchain" ]]; then
+      exec {real_cargo} "$toolchain" "$subcmd" "$@"
+    else
+      exec {real_cargo} "$subcmd" "$@"
+    fi
+    ;;
+esac
+"#,
+            real_cargo = shell_quote(&real_cargo),
+            log_path = shell_quote(&log_path),
+        );
+
+        let rustc_script = format!(
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${{1-}}" == +* && "${{2-}}" == "--version" ]]; then
+  echo "rustc 1.82.0-nightly (fake toolchain)"
+  exit 0
+fi
+
+exec {real_rustc} "$@"
+"#,
+            real_rustc = shell_quote(&real_rustc),
+        );
+
+        let rustup_script = r#"#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1-}" == "target" && "${2-}" == "list" && "${3-}" == "--installed" ]]; then
+  echo "wasm32-unknown-unknown"
+  exit 0
+fi
+
+if [[ "${1-}" == "component" && "${2-}" == "list" && "${3-}" == "--installed" ]]; then
+  echo "rust-src"
+  exit 0
+fi
+
+exit 0
+"#;
+
+        let wasm_opt_script = r#"#!/usr/bin/env bash
+set -euo pipefail
+
+input=""
+output=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      input="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$input" && -n "$output" ]]; then
+  if [[ "$input" != "$output" ]]; then
+    cp "$input" "$output"
+  fi
+fi
+"#;
+
+        write_executable(&bin_dir.join("cargo"), &cargo_script);
+        write_executable(&bin_dir.join("rustc"), &rustc_script);
+        write_executable(&bin_dir.join("rustup"), rustup_script);
+        write_executable(&bin_dir.join("wasm-opt"), wasm_opt_script);
+
+        Self {
+            _tmp: tmp,
+            bin_dir,
+            log_path,
+        }
+    }
+
+    fn path(&self) -> OsString {
+        let mut paths = vec![self.bin_dir.clone()];
+        paths.extend(env::split_paths(
+            &env::var_os("PATH").expect("PATH env var"),
+        ));
+        env::join_paths(paths).expect("join PATH")
+    }
+
+    fn log(&self) -> String {
+        fs::read_to_string(&self.log_path).unwrap_or_default()
+    }
+}
+
+#[test]
+fn check_succeeds_for_valid_project() {
+    let (_tmp, project) = create_project();
+    let tools = FakeTools::new();
+
+    cargo_bin_cmd!("dusk-forge")
+        .args(["check", "--path", project.to_str().expect("utf-8 path")])
+        .env("PATH", tools.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("All checks passed"));
+}
+
+#[test]
+fn build_creates_contract_and_data_driver_artifacts() {
+    let (_tmp, project) = create_project();
+    let tools = FakeTools::new();
+
+    cargo_bin_cmd!("dusk-forge")
+        .args(["build", "--path", project.to_str().expect("utf-8 path")])
+        .env("PATH", tools.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("contract wasm:"))
+        .stderr(predicate::str::contains("data-driver wasm:"));
+
+    assert!(project
+        .join("target/contract/wasm32-unknown-unknown/release/smoke_contract.wasm")
+        .exists());
+    assert!(project
+        .join("target/data-driver/wasm32-unknown-unknown/release/smoke_contract.wasm")
+        .exists());
+
+    let log = tools.log();
+    assert!(log.contains("subcmd=build toolchain=+nightly-2024-07-30 feature=contract"));
+    assert!(log.contains("subcmd=build toolchain=+nightly-2024-07-30 feature=data-driver-js"));
+    assert!(log.contains("target/contract"));
+    assert!(log.contains("target/data-driver"));
+}
+
+#[test]
+fn test_builds_contract_and_runs_cargo_test() {
+    let (_tmp, project) = create_project();
+    let tools = FakeTools::new();
+
+    cargo_bin_cmd!("dusk-forge")
+        .args([
+            "test",
+            "--path",
+            project.to_str().expect("utf-8 path"),
+            "--",
+            "--quiet",
+        ])
+        .env("PATH", tools.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Tests completed"));
+
+    assert!(project
+        .join("target/contract/wasm32-unknown-unknown/release/smoke_contract.wasm")
+        .exists());
+
+    let log = tools.log();
+    assert!(log.contains("subcmd=build toolchain=+nightly-2024-07-30 feature=contract"));
+    assert!(log.contains("subcmd=test toolchain=+nightly-2024-07-30"));
+    assert!(log.contains("--quiet"));
+}

--- a/cli/tests/dx_commands.rs
+++ b/cli/tests/dx_commands.rs
@@ -1,0 +1,69 @@
+use std::{fs, path::PathBuf};
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use tempfile::{tempdir, TempDir};
+
+fn scaffold_project(name: &str) -> (TempDir, PathBuf) {
+    let tmp = tempdir().expect("tempdir");
+
+    cargo_bin_cmd!("dusk-forge")
+        .args([
+            "new",
+            name,
+            "--no-git",
+            "--path",
+            tmp.path().to_str().expect("utf-8 path"),
+        ])
+        .assert()
+        .success();
+
+    let project = tmp.path().join(name);
+    (tmp, project)
+}
+
+#[test]
+fn clean_removes_contract_artifacts() {
+    let (_tmp, project) = scaffold_project("clean-me");
+
+    let contract_dir = project.join("target/contract/wasm32-unknown-unknown/release");
+    let data_driver_dir = project.join("target/data-driver/wasm32-unknown-unknown/release");
+
+    fs::create_dir_all(&contract_dir).expect("create contract target dir");
+    fs::create_dir_all(&data_driver_dir).expect("create data-driver target dir");
+    fs::write(contract_dir.join("clean_me.wasm"), b"contract").expect("write contract wasm");
+    fs::write(data_driver_dir.join("clean_me.wasm"), b"driver").expect("write data-driver wasm");
+
+    cargo_bin_cmd!("dusk-forge")
+        .args(["clean", "--path", project.to_str().expect("utf-8 path")])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Cleaned target/contract and target/data-driver",
+        ));
+
+    assert!(!project.join("target/contract").exists());
+    assert!(!project.join("target/data-driver").exists());
+}
+
+#[test]
+fn completions_generates_bash_output() {
+    cargo_bin_cmd!("dusk-forge")
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("dusk-forge"))
+        .stdout(predicate::str::contains("expand"))
+        .stdout(predicate::str::contains("clean"))
+        .stdout(predicate::str::contains("completions"));
+}
+
+#[test]
+fn expand_help_describes_data_driver_mode() {
+    cargo_bin_cmd!("dusk-forge")
+        .args(["expand", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("cargo-expand"))
+        .stdout(predicate::str::contains("--data-driver"));
+}


### PR DESCRIPTION
## Summary
- `expand`: show macro-expanded code via `cargo-expand`
- `clean`: remove `target/contract` and `target/data-driver` dirs
- `completions`: generate shell completion scripts (bash, zsh, fish, etc.)

## Stack
- PR 1/3: new, build, test, check
- **PR 2/3** (this) expand, clean, completions
- PR 3/3: schema, call, verify (wasmtime)
