### PR TITLE
Add schema, call, and verify commands to dusk-forge CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add the `dusk-forge` CLI with `new`, `build`, `test`, and `check` commands for contract project scaffolding and workflows.
 - Add `expand`, `clean`, and `completions` commands to the `dusk-forge` CLI.
+- Add `schema`, `call`, and `verify` commands to the `dusk-forge` CLI.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ predicates = "3"
 tempfile = "=3.10.1"
 thiserror = "2"
 toml = "0.8"
+wasmtime = "25"
 
 # Pin to match L1Contracts versions
 dusk-vm = { version = "=1.4.0", default-features = false }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,9 +15,16 @@ cargo_metadata = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 clap_complete = { workspace = true }
 colored = { workspace = true }
+blake3 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
+wasmtime = { workspace = true, optional = true }
+
+[features]
+default = ["schema"]
+schema = ["dep:wasmtime"]
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/cli/README.md
+++ b/cli/README.md
@@ -44,6 +44,9 @@ cargo run -p dusk-forge-cli -- --help
 - `dusk-forge check`: validate project structure and toolchain.
 - `dusk-forge expand [--data-driver]`: show macro expansion with `cargo-expand`.
 - `dusk-forge clean`: remove `target/contract` and `target/data-driver`.
+- `dusk-forge schema [--pretty]`: build data-driver WASM and print `CONTRACT_SCHEMA` JSON.
+- `dusk-forge call <function> [--input <json>]`: encode call bytes using the data-driver export `encode_input_fn`.
+- `dusk-forge verify [--expected-blake3 <hash>] [--skip-build]`: validate artifacts, schema loading, and optional contract hash match.
 - `dusk-forge completions <shell>`: generate shell completions.
 
 ## Common Options
@@ -65,6 +68,24 @@ dusk-forge check
 dusk-forge build
 dusk-forge build contract
 dusk-forge test
+```
+
+Print schema JSON:
+
+```bash
+dusk-forge schema --pretty
+```
+
+Encode input bytes for a function call:
+
+```bash
+dusk-forge call set_count --input '42'
+```
+
+Verify artifacts and hash:
+
+```bash
+dusk-forge verify --expected-blake3 <hash>
 ```
 
 ## Toolchain Requirements
@@ -100,4 +121,4 @@ Scaffolded projects include:
 - `rust-toolchain.toml` for deterministic toolchain selection
 - `Cargo.lock` generated at scaffold time
 
-Build/test commands run Cargo with `--locked`.
+Build/test/schema commands run Cargo with `--locked`.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -54,6 +54,12 @@ pub enum Commands {
     Expand(ExpandArgs),
     /// Remove contract-specific build artifact directories.
     Clean(ProjectOptions),
+    /// Build data-driver WASM and print CONTRACT_SCHEMA as JSON.
+    Schema(SchemaArgs),
+    /// Encode call input bytes through the data-driver.
+    Call(CallArgs),
+    /// Verify contract and data-driver artifacts.
+    Verify(VerifyArgs),
     /// Generate shell completion scripts.
     Completions(CompletionsArgs),
 }
@@ -128,6 +134,43 @@ pub struct ExpandArgs {
 }
 
 #[derive(Debug, Args)]
+pub struct SchemaArgs {
+    #[command(flatten)]
+    pub project: ProjectOptions,
+
+    /// Pretty-print JSON output.
+    #[arg(long)]
+    pub pretty: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct CallArgs {
+    #[command(flatten)]
+    pub project: ProjectOptions,
+
+    /// Contract function name to encode.
+    pub function: String,
+
+    /// JSON input payload for the function (use `null` for no input).
+    #[arg(long, default_value = "null")]
+    pub input: String,
+}
+
+#[derive(Debug, Args)]
+pub struct VerifyArgs {
+    #[command(flatten)]
+    pub project: ProjectOptions,
+
+    /// Optional expected BLAKE3 hash of the contract WASM.
+    #[arg(long)]
+    pub expected_blake3: Option<String>,
+
+    /// Skip rebuilding artifacts and verify existing files only.
+    #[arg(long)]
+    pub skip_build: bool,
+}
+
+#[derive(Debug, Args)]
 pub struct CompletionsArgs {
     /// Shell to generate completions for.
     #[arg(value_enum)]
@@ -169,6 +212,48 @@ mod tests {
         match cli.command {
             Commands::Completions(_) => {}
             other => panic!("expected completions command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_schema_command() {
+        let cli = Cli::parse_from(["dusk-forge", "schema", "--pretty"]);
+
+        match cli.command {
+            Commands::Schema(args) => assert!(args.pretty),
+            other => panic!("expected schema command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_call_command() {
+        let cli = Cli::parse_from(["dusk-forge", "call", "transfer", "--input", "{\"foo\":1}"]);
+
+        match cli.command {
+            Commands::Call(args) => {
+                assert_eq!(args.function, "transfer");
+                assert_eq!(args.input, "{\"foo\":1}");
+            }
+            other => panic!("expected call command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_verify_command() {
+        let cli = Cli::parse_from([
+            "dusk-forge",
+            "verify",
+            "--expected-blake3",
+            "deadbeef",
+            "--skip-build",
+        ]);
+
+        match cli.command {
+            Commands::Verify(args) => {
+                assert_eq!(args.expected_blake3.as_deref(), Some("deadbeef"));
+                assert!(args.skip_build);
+            }
+            other => panic!("expected verify command, got {other:?}"),
         }
     }
 }

--- a/cli/src/commands/call.rs
+++ b/cli/src/commands/call.rs
@@ -1,0 +1,64 @@
+use crate::{cli::CallArgs, error::Result};
+
+#[cfg(feature = "schema")]
+use crate::{
+    build_runner::{self, BuildTarget},
+    data_driver_wasm::DataDriverWasm,
+    project::{detect, metadata},
+    toolchain, ui,
+};
+
+#[cfg(feature = "schema")]
+pub fn run(args: CallArgs) -> Result<()> {
+    let project = metadata::load(&args.project.path)?;
+    detect::ensure_forge_project(&project.project_dir)?;
+
+    toolchain::ensure_build(&project.project_dir, false)?;
+
+    ui::status(format!(
+        "Building data-driver WASM for function '{}'",
+        args.function
+    ));
+
+    let wasm_path = build_runner::build(&project, BuildTarget::DataDriver, args.project.verbose)?;
+    let optimized =
+        build_runner::wasm_opt::optimize_if_available(&wasm_path, args.project.verbose)?;
+    if !optimized {
+        ui::warn("wasm-opt not found, skipping optimization");
+    }
+
+    let mut driver = DataDriverWasm::load(&wasm_path)?;
+    let encoded = driver.encode_input(&args.function, &args.input)?;
+
+    if args.project.verbose {
+        ui::status(format!(
+            "Encoded {} bytes for '{}'",
+            encoded.len(),
+            args.function
+        ));
+    }
+
+    println!("{}", to_hex_prefixed(&encoded));
+    ui::success("Call payload encoded");
+    Ok(())
+}
+
+#[cfg(not(feature = "schema"))]
+pub fn run(_args: CallArgs) -> Result<()> {
+    Err(crate::error::CliError::Message(
+        "call command is disabled (build with --features schema)".to_string(),
+    ))
+}
+
+#[cfg(feature = "schema")]
+fn to_hex_prefixed(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2 + 2);
+    out.push_str("0x");
+
+    for byte in bytes {
+        use std::fmt::Write;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+
+    out
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,7 +1,10 @@
 pub mod build;
+pub mod call;
 pub mod check;
 pub mod clean;
 pub mod completions;
 pub mod expand;
 pub mod new;
+pub mod schema;
 pub mod test;
+pub mod verify;

--- a/cli/src/commands/schema.rs
+++ b/cli/src/commands/schema.rs
@@ -1,0 +1,44 @@
+use crate::{cli::SchemaArgs, error::Result};
+
+#[cfg(feature = "schema")]
+use crate::{
+    build_runner::{self, BuildTarget},
+    data_driver_wasm::DataDriverWasm,
+    project::{detect, metadata},
+    toolchain, ui,
+};
+
+#[cfg(feature = "schema")]
+pub fn run(args: SchemaArgs) -> Result<()> {
+    let project = metadata::load(&args.project.path)?;
+    detect::ensure_forge_project(&project.project_dir)?;
+
+    toolchain::ensure_build(&project.project_dir, false)?;
+
+    ui::status("Building data-driver WASM");
+    let wasm_path = build_runner::build(&project, BuildTarget::DataDriver, args.project.verbose)?;
+    let optimized =
+        build_runner::wasm_opt::optimize_if_available(&wasm_path, args.project.verbose)?;
+    if !optimized {
+        ui::warn("wasm-opt not found, skipping optimization");
+    }
+
+    let mut driver = DataDriverWasm::load(&wasm_path)?;
+    let schema_json = driver.get_schema_json()?;
+    let parsed: serde_json::Value = serde_json::from_str(&schema_json)?;
+
+    if args.pretty {
+        println!("{}", serde_json::to_string_pretty(&parsed)?);
+    } else {
+        println!("{}", serde_json::to_string(&parsed)?);
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "schema"))]
+pub fn run(_args: SchemaArgs) -> Result<()> {
+    Err(crate::error::CliError::Message(
+        "schema command is disabled (build with --features schema)".to_string(),
+    ))
+}

--- a/cli/src/commands/verify.rs
+++ b/cli/src/commands/verify.rs
@@ -1,0 +1,119 @@
+#[cfg(feature = "schema")]
+use std::fs;
+
+use crate::{cli::VerifyArgs, error::Result};
+
+#[cfg(feature = "schema")]
+use crate::{
+    build_runner::{self, BuildTarget},
+    data_driver_wasm::DataDriverWasm,
+    error::CliError,
+    project::{detect, metadata},
+    toolchain, ui,
+};
+
+#[cfg(feature = "schema")]
+pub fn run(args: VerifyArgs) -> Result<()> {
+    let project = metadata::load(&args.project.path)?;
+    detect::ensure_forge_project(&project.project_dir)?;
+
+    let contract_wasm = if args.skip_build {
+        project.contract_wasm_path.clone()
+    } else {
+        toolchain::ensure_build(&project.project_dir, true)?;
+        ui::status("Building contract WASM for verification");
+        let wasm = build_runner::build(&project, BuildTarget::Contract, args.project.verbose)?;
+        let optimized = build_runner::wasm_opt::optimize_if_available(&wasm, args.project.verbose)?;
+        if !optimized {
+            ui::warn("wasm-opt not found, skipping optimization");
+        }
+        wasm
+    };
+
+    let data_driver_wasm = if args.skip_build {
+        project.data_driver_wasm_path.clone()
+    } else {
+        toolchain::ensure_build(&project.project_dir, false)?;
+        ui::status("Building data-driver WASM for verification");
+        let wasm = build_runner::build(&project, BuildTarget::DataDriver, args.project.verbose)?;
+        let optimized = build_runner::wasm_opt::optimize_if_available(&wasm, args.project.verbose)?;
+        if !optimized {
+            ui::warn("wasm-opt not found, skipping optimization");
+        }
+        wasm
+    };
+
+    if !contract_wasm.exists() {
+        return Err(CliError::Message(format!(
+            "contract WASM not found: {}",
+            contract_wasm.display()
+        )));
+    }
+
+    if !data_driver_wasm.exists() {
+        return Err(CliError::Message(format!(
+            "data-driver WASM not found: {}",
+            data_driver_wasm.display()
+        )));
+    }
+
+    DataDriverWasm::validate_module(&contract_wasm)?;
+    ui::success(format!("Valid WASM module: {}", contract_wasm.display()));
+
+    DataDriverWasm::validate_module(&data_driver_wasm)?;
+    ui::success(format!("Valid WASM module: {}", data_driver_wasm.display()));
+
+    let contract_bytes = fs::read(&contract_wasm)?;
+    let actual_hash = blake3::hash(&contract_bytes).to_hex().to_string();
+
+    if let Some(expected) = args.expected_blake3 {
+        let expected_normalized = expected.trim_start_matches("0x").to_ascii_lowercase();
+        if actual_hash != expected_normalized {
+            return Err(CliError::Message(format!(
+                "BLAKE3 mismatch: expected {expected_normalized}, got {actual_hash}"
+            )));
+        }
+        ui::success("Contract BLAKE3 hash matches expected value");
+    }
+
+    let mut driver = DataDriverWasm::load(&data_driver_wasm)?;
+    let schema_json = driver.get_schema_json()?;
+    let schema: serde_json::Value = serde_json::from_str(&schema_json)?;
+
+    let contract_name = schema
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| CliError::Message("schema is missing 'name'".to_string()))?;
+
+    let function_count = schema
+        .get("functions")
+        .and_then(serde_json::Value::as_array)
+        .map(std::vec::Vec::len)
+        .ok_or_else(|| CliError::Message("schema is missing 'functions' array".to_string()))?;
+
+    ui::success(format!(
+        "Schema loaded for {contract_name} with {function_count} function(s)"
+    ));
+
+    if function_count == 0 {
+        return Err(CliError::Message(
+            "schema contains zero functions".to_string(),
+        ));
+    }
+
+    println!("contract_wasm: {}", contract_wasm.display());
+    println!("data_driver_wasm: {}", data_driver_wasm.display());
+    println!("contract_blake3: {actual_hash}");
+    println!("schema_contract: {contract_name}");
+    println!("schema_functions: {function_count}");
+
+    ui::success("Verification passed");
+    Ok(())
+}
+
+#[cfg(not(feature = "schema"))]
+pub fn run(_args: VerifyArgs) -> Result<()> {
+    Err(crate::error::CliError::Message(
+        "verify command is disabled (build with --features schema)".to_string(),
+    ))
+}

--- a/cli/src/data_driver_wasm.rs
+++ b/cli/src/data_driver_wasm.rs
@@ -1,0 +1,201 @@
+#[cfg(feature = "schema")]
+use std::path::Path;
+
+#[cfg(feature = "schema")]
+use wasmtime::{Engine, Instance, Memory, Module, Store, TypedFunc};
+
+#[cfg(feature = "schema")]
+use crate::error::{CliError, Result};
+
+#[cfg(feature = "schema")]
+pub struct DataDriverWasm {
+    store: Store<()>,
+    instance: Instance,
+    memory: Memory,
+}
+
+#[cfg(feature = "schema")]
+impl DataDriverWasm {
+    pub fn load(wasm_path: &Path) -> Result<Self> {
+        let engine = Engine::default();
+        let module = Module::from_file(&engine, wasm_path)?;
+
+        let mut store = Store::new(&engine, ());
+        let instance = Instance::new(&mut store, &module, &[])?;
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| CliError::Message("WASM export 'memory' not found".to_string()))?;
+
+        let init = instance
+            .get_typed_func::<(), ()>(&mut store, "init")
+            .map_err(|_| CliError::Message("WASM export 'init' not found".to_string()))?;
+        init.call(&mut store, ())?;
+
+        Ok(Self {
+            store,
+            instance,
+            memory,
+        })
+    }
+
+    pub fn get_schema_json(&mut self) -> Result<String> {
+        let out_offset: usize = 64 * 1024;
+        let out_size: usize = 256 * 1024;
+
+        self.ensure_memory_capacity((out_offset + out_size) as u64)?;
+
+        let get_schema = self
+            .instance
+            .get_typed_func::<(i32, i32), i32>(&mut self.store, "get_schema")
+            .map_err(|_| CliError::Message("WASM export 'get_schema' not found".to_string()))?;
+
+        let code = get_schema.call(&mut self.store, (out_offset as i32, out_size as i32))?;
+        if code != 0 {
+            let detail = self
+                .read_last_error()
+                .unwrap_or_else(|| "unknown error".to_string());
+            return Err(CliError::Message(format!(
+                "get_schema failed with code {code}: {detail}"
+            )));
+        }
+
+        let bytes = self.read_prefixed_bytes(out_offset)?;
+        String::from_utf8(bytes)
+            .map_err(|err| CliError::Message(format!("schema output is not valid UTF-8: {err}")))
+    }
+
+    pub fn encode_input(&mut self, function: &str, json: &str) -> Result<Vec<u8>> {
+        let fn_name = function.as_bytes();
+        let json = json.as_bytes();
+
+        let fn_offset = 1024usize;
+        let json_offset = align_up(fn_offset + fn_name.len() + 16, 8);
+        let out_offset = align_up(json_offset + json.len() + 16, 8);
+        let out_size = (json.len() * 2).max(4096);
+
+        self.ensure_memory_capacity((out_offset + out_size) as u64)?;
+
+        self.write_bytes(fn_offset, fn_name)?;
+        self.write_bytes(json_offset, json)?;
+
+        let encode_input_fn = self
+            .instance
+            .get_typed_func::<(i32, i32, i32, i32, i32, i32), i32>(
+                &mut self.store,
+                "encode_input_fn",
+            )
+            .map_err(|_| {
+                CliError::Message("WASM export 'encode_input_fn' not found".to_string())
+            })?;
+
+        let code = encode_input_fn.call(
+            &mut self.store,
+            (
+                fn_offset as i32,
+                fn_name.len() as i32,
+                json_offset as i32,
+                json.len() as i32,
+                out_offset as i32,
+                out_size as i32,
+            ),
+        )?;
+
+        if code != 0 {
+            let detail = self
+                .read_last_error()
+                .unwrap_or_else(|| "unknown error".to_string());
+            return Err(CliError::Message(format!(
+                "encode_input_fn failed with code {code}: {detail}"
+            )));
+        }
+
+        self.read_prefixed_bytes(out_offset)
+    }
+
+    pub fn validate_module(wasm_path: &Path) -> Result<()> {
+        let engine = Engine::default();
+        let _ = Module::from_file(&engine, wasm_path)?;
+        Ok(())
+    }
+
+    fn read_last_error(&mut self) -> Option<String> {
+        let get_last_error: TypedFunc<(i32, i32), i32> = self
+            .instance
+            .get_typed_func::<(i32, i32), i32>(&mut self.store, "get_last_error")
+            .ok()?;
+
+        let out_offset: usize = 16 * 1024;
+        let out_size: usize = 8 * 1024;
+
+        self.ensure_memory_capacity((out_offset + out_size) as u64)
+            .ok()?;
+
+        let code = get_last_error
+            .call(&mut self.store, (out_offset as i32, out_size as i32))
+            .ok()?;
+        if code != 0 {
+            return None;
+        }
+
+        let bytes = self.read_prefixed_bytes(out_offset).ok()?;
+        String::from_utf8(bytes).ok()
+    }
+
+    fn ensure_memory_capacity(&mut self, required_bytes: u64) -> Result<()> {
+        let current_pages = self.memory.size(&mut self.store);
+        let required_pages = required_bytes.div_ceil(65_536);
+
+        if current_pages < required_pages {
+            self.memory
+                .grow(&mut self.store, required_pages - current_pages)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_bytes(&mut self, offset: usize, data: &[u8]) -> Result<()> {
+        let mem = self.memory.data_mut(&mut self.store);
+        let end = offset + data.len();
+        if end > mem.len() {
+            return Err(CliError::Message(format!(
+                "WASM write out of bounds (offset={offset}, len={})",
+                data.len()
+            )));
+        }
+
+        mem[offset..end].copy_from_slice(data);
+        Ok(())
+    }
+
+    fn read_prefixed_bytes(&self, offset: usize) -> Result<Vec<u8>> {
+        let data = self.memory.data(&self.store);
+
+        if offset + 4 > data.len() {
+            return Err(CliError::Message(
+                "WASM output buffer out of bounds".to_string(),
+            ));
+        }
+
+        let len = u32::from_le_bytes([
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ]) as usize;
+
+        let start = offset + 4;
+        let end = start + len;
+        if end > data.len() {
+            return Err(CliError::Message(
+                "WASM output exceeds memory bounds".to_string(),
+            ));
+        }
+
+        Ok(data[start..end].to_vec())
+    }
+}
+
+#[cfg(feature = "schema")]
+fn align_up(value: usize, align: usize) -> usize {
+    value.div_ceil(align) * align
+}

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -35,4 +35,11 @@ pub enum CliError {
 
     #[error("TOML parse error: {0}")]
     Toml(#[from] toml::de::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[cfg(feature = "schema")]
+    #[error("wasm runtime error: {0}")]
+    Wasm(#[from] wasmtime::Error),
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod build_runner;
 mod cli;
 mod commands;
+mod data_driver_wasm;
 mod error;
 mod project;
 mod template;
@@ -29,6 +30,9 @@ fn run() -> Result<()> {
         Commands::Check(args) => commands::check::run(args),
         Commands::Expand(args) => commands::expand::run(args),
         Commands::Clean(args) => commands::clean::run(args),
+        Commands::Schema(args) => commands::schema::run(args),
+        Commands::Call(args) => commands::call::run(args),
+        Commands::Verify(args) => commands::verify::run(args),
         Commands::Completions(args) => commands::completions::run(args),
     }
 }


### PR DESCRIPTION
## Summary
- `schema`: build data-driver WASM, load it with wasmtime, extract `CONTRACT_SCHEMA` as JSON
- `call` / `verify`: stub commands (print "coming soon")
- Feature-gated behind `schema` (pulls in wasmtime)

## Stack
- PR 1/3: new, build, test, check
- PR 2/3: expand, clean, completions
- **PR 3/3** (this) schema, call, verify (wasmtime)