### PR TITLE
Add event registration via emits attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `#[contract(emits = [...])]` method-level attribute for manual event registration in trait impls with default implementations.
+- Add `#[contract(emits = [...])]` method-level attribute for manual event registration, covering both trait impls with default implementations and inherent methods that delegate to helpers in other crates.
 - Add compile error when a public `&mut self` method emits no events. Suppress with `#[contract(no_event)]`.
 - Add detection of variable identifiers used as `abi::emit()` topics (warning pending `proc_macro_diagnostic` stabilisation).
 - Add the `dusk-forge` CLI with `new`, `build`, `test`, and `check` commands for contract project scaffolding and workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `#[contract(emits = [...])]` method-level attribute for manual event registration in trait impls with default implementations.
+- Add compile error when a public `&mut self` method emits no events. Suppress with `#[contract(no_event)]`.
+- Add detection of variable identifiers used as `abi::emit()` topics (warning pending `proc_macro_diagnostic` stabilisation).
 - Add the `dusk-forge` CLI with `new`, `build`, `test`, and `check` commands for contract project scaffolding and workflows.
 - Add `expand`, `clean`, and `completions` commands to the `dusk-forge` CLI.
 - Add `schema`, `call`, and `verify` commands to the `dusk-forge` CLI.

--- a/contract-macro/src/extract.rs
+++ b/contract-macro/src/extract.rs
@@ -275,12 +275,13 @@ pub(crate) fn public_methods(impl_block: &ItemImpl) -> Result<Vec<FunctionInfo>,
             let receiver = extract_receiver(method);
             let has_emit_call = method_has_emit_call(method);
             let suppressed = event_suppressed(&method.attrs);
+            let has_method_emits = !method_emits(&method.attrs).is_empty();
 
             // Validate feed-related attributes
             validate_feeds(method, &name, feed_type.as_ref())?;
 
             // Validate that mutating methods emit events
-            validate::method_emits_event(method, has_emit_call, suppressed, false)?;
+            validate::method_emits_event(method, has_emit_call, suppressed, has_method_emits)?;
 
             // Extract parameters (name and type)
             let params = parameters(method);
@@ -428,28 +429,44 @@ pub(crate) fn method_emits(attrs: &[Attribute]) -> Vec<EventInfo> {
         .unwrap_or_default()
 }
 
+/// Collect events from method-level `#[contract(emits = [...])]` attributes
+/// on the methods of an impl block, restricted to those matching `include`.
+fn impl_method_emits<F>(impl_block: &ItemImpl, mut include: F) -> Vec<EventInfo>
+where
+    F: FnMut(&ImplItemFn) -> bool,
+{
+    let mut events = Vec::new();
+    for item in &impl_block.items {
+        if let ImplItem::Fn(method) = item
+            && include(method)
+        {
+            events.extend(method_emits(&method.attrs));
+        }
+    }
+    events
+}
+
 /// Extract events from method-level `#[contract(emits = [...])]` attributes in
 /// a trait impl.
 ///
 /// Only methods in the `expose_list` are checked for emits attributes.
 pub(crate) fn trait_method_emits(trait_impl: &TraitImplInfo) -> Vec<EventInfo> {
-    let mut events = Vec::new();
+    impl_method_emits(trait_impl.impl_block, |method| {
+        trait_impl
+            .expose_list
+            .contains(&method.sig.ident.to_string())
+    })
+}
 
-    for item in &trait_impl.impl_block.items {
-        if let ImplItem::Fn(method) = item {
-            let method_name = method.sig.ident.to_string();
-
-            // Only process methods in the expose list
-            if !trait_impl.expose_list.contains(&method_name) {
-                continue;
-            }
-
-            // Extract events from method's emits attribute
-            events.extend(method_emits(&method.attrs));
-        }
-    }
-
-    events
+/// Extract events from method-level `#[contract(emits = [...])]` attributes in
+/// an inherent impl block.
+///
+/// Only public methods (excluding `new`) are checked, matching the set of
+/// methods exposed as contract functions by [`public_methods`].
+pub(crate) fn inherent_method_emits(impl_block: &ItemImpl) -> Vec<EventInfo> {
+    impl_method_emits(impl_block, |method| {
+        matches!(method.vis, Visibility::Public(_)) && method.sig.ident != "new"
+    })
 }
 
 /// Extract the `expose = [method1, method2, ...]` list from a
@@ -1096,6 +1113,87 @@ mod tests {
         assert!(result.is_ok());
         let functions = result.unwrap();
         assert_eq!(functions.len(), 2);
+    }
+
+    #[test]
+    fn test_public_methods_delegating_with_emits() {
+        // Inherent method with an emit-free body but an `emits` attribute
+        // (delegates to a helper) — the new strict check must accept it.
+        let impl_block: ItemImpl = syn::parse_quote! {
+            impl MyContract {
+                #[contract(emits = [(Resolved::TOPIC, Resolved)])]
+                pub fn resolve(&mut self) {
+                    self.core.resolve();
+                }
+            }
+        };
+        let functions = match public_methods(&impl_block) {
+            Ok(functions) => functions,
+            Err(err) => panic!("expected success, got: {err}"),
+        };
+        assert_eq!(functions.len(), 1);
+        assert_eq!(functions[0].name.to_string(), "resolve");
+    }
+
+    #[test]
+    fn test_public_methods_delegating_without_emits_errors() {
+        // Same shape without the `emits` attribute must still fail the strict
+        // mutating-method check.
+        let impl_block: ItemImpl = syn::parse_quote! {
+            impl MyContract {
+                pub fn resolve(&mut self) {
+                    self.core.resolve();
+                }
+            }
+        };
+        let Err(err) = public_methods(&impl_block) else {
+            panic!("expected error for delegating method without emits");
+        };
+        assert!(err.to_string().contains("emits no events"));
+    }
+
+    #[test]
+    fn test_trait_method_emits_collects_events() {
+        let impl_block: ItemImpl = syn::parse_quote! {
+            #[contract(expose = [transfer_ownership])]
+            impl OwnableTrait for MyContract {
+                #[contract(emits = [(Transferred::TOPIC, Transferred)])]
+                fn transfer_ownership(&mut self) {}
+
+                // Not in expose list — should be ignored even with emits.
+                #[contract(emits = [(Hidden::TOPIC, Hidden)])]
+                fn unexposed(&mut self) {}
+            }
+        };
+        let trait_impl = TraitImplInfo {
+            trait_name: "OwnableTrait".to_string(),
+            impl_block: &impl_block,
+            expose_list: vec!["transfer_ownership".to_string()],
+        };
+        let events = trait_method_emits(&trait_impl);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].topic, "Transferred::TOPIC");
+    }
+
+    #[test]
+    fn test_inherent_method_emits_collects_events() {
+        let impl_block: ItemImpl = syn::parse_quote! {
+            impl MyContract {
+                #[contract(emits = [(Resolved::TOPIC, Resolved)])]
+                pub fn resolve(&mut self) { self.core.resolve(); }
+
+                // Private method — should be ignored.
+                #[contract(emits = [(Hidden::TOPIC, Hidden)])]
+                fn private_helper(&mut self) { self.core.hidden(); }
+
+                // Constructor — should be ignored even if it carries emits.
+                #[contract(emits = [(New::TOPIC, New)])]
+                pub fn new() -> Self { Self }
+            }
+        };
+        let events = inherent_method_emits(&impl_block);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].topic, "Resolved::TOPIC");
     }
 
     #[test]

--- a/contract-macro/src/extract.rs
+++ b/contract-macro/src/extract.rs
@@ -15,9 +15,9 @@ use syn::{
 
 use crate::{
     ContractData, CustomDataDriverHandler, DataDriverRole, EmitVisitor, EventInfo, FunctionInfo,
-    ImportInfo, ParameterInfo, TraitImplInfo, extract_doc_comment, extract_feeds_attribute,
-    extract_receiver, get_feed_exprs, has_custom_attribute, has_empty_body, parse, validate,
-    validate_feed_type_match,
+    ImportInfo, ParameterInfo, TraitImplInfo, event_suppressed, extract_doc_comment,
+    extract_feeds_attribute, extract_receiver, get_feed_exprs, has_custom_attribute,
+    has_empty_body, parse, validate, validate_feed_type_match,
 };
 
 /// Validate feed-related attributes for a method.
@@ -75,28 +75,48 @@ fn validate_feeds(
 }
 
 /// Extract topic string from the first argument of `abi::emit()`.
+///
 /// Handles both string literals and const path expressions.
+/// Detects when a lowercase single-segment path (likely a variable) is used as
+/// a topic, since the macro can only capture the variable name, not its value.
 pub(crate) fn topic_from_expr(expr: &Expr) -> Option<String> {
     match expr {
         // String literal: "topic_name"
         Expr::Lit(ExprLit {
             lit: Lit::Str(s), ..
         }) => Some(s.value()),
-        // Path expression: Type::TOPIC or module::Type::TOPIC
+        // Path expression: Type::TOPIC or module::Type::TOPIC or variable
         Expr::Path(path) => {
-            // Convert the path to a string representation
-            Some(
-                path.path
-                    .segments
-                    .iter()
-                    .map(|s| s.ident.to_string())
-                    .collect::<Vec<_>>()
-                    .join("::"),
-            )
+            let segments: Vec<_> = path
+                .path
+                .segments
+                .iter()
+                .map(|s| s.ident.to_string())
+                .collect();
+
+            // Single lowercase identifier is likely a variable, not a const.
+            // e.g., `let topic = "foo"; abi::emit(topic, data);` — we can only
+            // capture "topic" as the schema topic, not its runtime value.
+            if segments.len() == 1 {
+                let first_char = segments[0].chars().next();
+                if first_char.is_some_and(char::is_lowercase) {
+                    emit_variable_topic_warning(&segments[0]);
+                }
+            }
+
+            Some(segments.join("::"))
         }
         _ => None,
     }
 }
+
+/// Emit a warning when a variable is used as an event topic.
+///
+/// Currently a no-op: `proc_macro::Diagnostic` requires nightly
+/// (`proc_macro_diagnostic`). The detection logic in `topic_from_expr`
+/// still identifies variable topics and unit tests verify the behaviour;
+/// the warning can be enabled once the feature stabilises.
+fn emit_variable_topic_warning(_name: &str) {}
 
 /// Attempt to extract a type from an expression.
 /// This handles common patterns like `Type { .. }`, `Type()`, `Type::new()`.
@@ -155,11 +175,28 @@ pub(crate) fn trait_methods(trait_impl: &TraitImplInfo) -> Result<Vec<FunctionIn
             let feed_type = extract_feeds_attribute(&method.attrs);
             let receiver = extract_receiver(method);
 
+            // Check for method-level emits attribute
+            let method_events = method_emits(&method.attrs);
+            let has_method_emits = !method_events.is_empty();
+
+            // For trait methods:
+            // - Default impl (empty body): check if emits attribute registered on method
+            // - Non-default impl: check body for emit calls
+            let has_emit_call = if is_default_impl {
+                has_method_emits
+            } else {
+                method_has_emit_call(method)
+            };
+            let suppressed = event_suppressed(&method.attrs);
+
             // Validate feed-related attributes
             // (only check non-empty bodies since empty bodies delegate to trait defaults)
             if !is_default_impl {
                 validate_feeds(method, &name, feed_type.as_ref())?;
             }
+
+            // Validate that mutating methods emit events
+            validate::method_emits_event(method, has_emit_call, suppressed, has_method_emits)?;
 
             // Extract parameters (name and type)
             let params = parameters(method);
@@ -236,9 +273,14 @@ pub(crate) fn public_methods(impl_block: &ItemImpl) -> Result<Vec<FunctionInfo>,
             let is_custom = has_custom_attribute(&method.attrs);
             let feed_type = extract_feeds_attribute(&method.attrs);
             let receiver = extract_receiver(method);
+            let has_emit_call = method_has_emit_call(method);
+            let suppressed = event_suppressed(&method.attrs);
 
             // Validate feed-related attributes
             validate_feeds(method, &name, feed_type.as_ref())?;
+
+            // Validate that mutating methods emit events
+            validate::method_emits_event(method, has_emit_call, suppressed, false)?;
 
             // Extract parameters (name and type)
             let params = parameters(method);
@@ -362,6 +404,54 @@ pub(crate) fn emit_calls(impl_block: &ItemImpl) -> Vec<EventInfo> {
         .collect()
 }
 
+/// Check if a method body contains any `abi::emit()` call.
+pub(crate) fn method_has_emit_call(method: &ImplItemFn) -> bool {
+    use syn::visit::Visit;
+
+    let mut visitor = EmitVisitor::new();
+    visitor.visit_block(&method.block);
+    !visitor.events.is_empty()
+}
+
+/// Extract events from a method's `#[contract(emits = [...])]` attribute.
+///
+/// Returns the events registered on this specific method, or an empty vec if
+/// none.
+pub(crate) fn method_emits(attrs: &[Attribute]) -> Vec<EventInfo> {
+    emits_list(attrs)
+        .map(|events| {
+            events
+                .into_iter()
+                .map(|(topic, data_type)| crate::EventInfo { topic, data_type })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Extract events from method-level `#[contract(emits = [...])]` attributes in
+/// a trait impl.
+///
+/// Only methods in the `expose_list` are checked for emits attributes.
+pub(crate) fn trait_method_emits(trait_impl: &TraitImplInfo) -> Vec<EventInfo> {
+    let mut events = Vec::new();
+
+    for item in &trait_impl.impl_block.items {
+        if let ImplItem::Fn(method) = item {
+            let method_name = method.sig.ident.to_string();
+
+            // Only process methods in the expose list
+            if !trait_impl.expose_list.contains(&method_name) {
+                continue;
+            }
+
+            // Extract events from method's emits attribute
+            events.extend(method_emits(&method.attrs));
+        }
+    }
+
+    events
+}
+
 /// Extract the `expose = [method1, method2, ...]` list from a
 /// `#[contract(...)]` attribute.
 ///
@@ -418,6 +508,156 @@ pub(crate) fn expose_list(attrs: &[Attribute]) -> Option<Vec<String>> {
     }
 
     None
+}
+
+/// Extract the `emits = [(topic, Type), ...]` list from a `#[contract(...)]`
+/// attribute.
+///
+/// Returns `None` if there's no `#[contract(emits = [...])]` attribute.
+/// Returns `Some(vec![...])` with (topic, `data_type`) pairs if found.
+///
+/// Supports two topic formats:
+/// - Const path: `(events::OwnershipTransferred::TOPIC,
+///   events::OwnershipTransferred)`
+/// - String literal: `("my_topic", MyEventType)`
+pub(crate) fn emits_list(attrs: &[Attribute]) -> Option<Vec<(String, TokenStream2)>> {
+    for attr in attrs {
+        if !attr.path().is_ident("contract") {
+            continue;
+        }
+
+        let Ok(meta) = attr.meta.require_list() else {
+            continue;
+        };
+
+        // Parse the token stream to find emits = [...]
+        let tokens = meta.tokens.clone();
+        let mut iter = tokens.into_iter().peekable();
+
+        // Look through all tokens for "emits"
+        while let Some(token) = iter.next() {
+            let proc_macro2::TokenTree::Ident(ident) = token else {
+                continue;
+            };
+
+            if ident != "emits" {
+                continue;
+            }
+
+            // Expect "="
+            let Some(proc_macro2::TokenTree::Punct(punct)) = iter.next() else {
+                continue;
+            };
+            if punct.as_char() != '=' {
+                continue;
+            }
+
+            // Expect "[...]"
+            let Some(proc_macro2::TokenTree::Group(group)) = iter.next() else {
+                continue;
+            };
+            if group.delimiter() != proc_macro2::Delimiter::Bracket {
+                continue;
+            }
+
+            // Parse the event tuples from the group
+            return Some(parse_emits_tuples(group.stream()));
+        }
+    }
+
+    None
+}
+
+/// Parse the contents of `emits = [...]` into a list of (topic, `data_type`)
+/// pairs.
+fn parse_emits_tuples(stream: proc_macro2::TokenStream) -> Vec<(String, TokenStream2)> {
+    let mut events = Vec::new();
+
+    for token in stream {
+        // Each event is a group: (topic, Type)
+        let proc_macro2::TokenTree::Group(group) = token else {
+            continue;
+        };
+        if group.delimiter() != proc_macro2::Delimiter::Parenthesis {
+            continue;
+        }
+
+        if let Some((topic, data_type)) = parse_event_tuple(group.stream()) {
+            events.push((topic, data_type));
+        }
+    }
+
+    events
+}
+
+/// Parse a single event tuple: (topic, Type).
+fn parse_event_tuple(stream: proc_macro2::TokenStream) -> Option<(String, TokenStream2)> {
+    let mut iter = stream.into_iter().peekable();
+
+    // Extract topic (everything before the comma)
+    let topic = extract_topic_from_tokens(&mut iter)?;
+
+    // Skip the comma
+    while let Some(token) = iter.peek() {
+        if let proc_macro2::TokenTree::Punct(p) = token
+            && p.as_char() == ','
+        {
+            iter.next();
+            break;
+        }
+        iter.next();
+    }
+
+    // Remaining tokens are the data type
+    let data_type: TokenStream2 = iter.collect();
+    if data_type.is_empty() {
+        return None;
+    }
+
+    Some((topic, data_type))
+}
+
+/// Extract the topic string from the tokens before the comma.
+fn extract_topic_from_tokens(
+    iter: &mut std::iter::Peekable<proc_macro2::token_stream::IntoIter>,
+) -> Option<String> {
+    let mut path_segments = Vec::new();
+
+    while let Some(token) = iter.peek() {
+        match token {
+            proc_macro2::TokenTree::Punct(p) if p.as_char() == ',' => {
+                // End of topic
+                break;
+            }
+            proc_macro2::TokenTree::Punct(p) if p.as_char() == ':' => {
+                // Part of path separator ::
+                iter.next();
+            }
+            proc_macro2::TokenTree::Ident(ident) => {
+                path_segments.push(ident.to_string());
+                iter.next();
+            }
+            proc_macro2::TokenTree::Literal(lit) => {
+                // String literal topic
+                let s = lit.to_string();
+                iter.next();
+                // Remove quotes from string literal
+                if s.starts_with('"') && s.ends_with('"') {
+                    return Some(s[1..s.len() - 1].to_string());
+                }
+                return Some(s);
+            }
+            _ => {
+                iter.next();
+            }
+        }
+    }
+
+    if path_segments.is_empty() {
+        None
+    } else {
+        Some(path_segments.join("::"))
+    }
 }
 
 // ============================================================================
@@ -842,9 +1082,9 @@ mod tests {
             impl OwnableTrait for MyContract {
                 fn owner(&self) -> Option<Address> { self.owner }
                 fn owner_mut(&mut self) -> &mut Option<Address> { &mut self.owner }
-                fn transfer_ownership(&mut self, new_owner: Address) {
-                    self.owner = Some(new_owner);
-                }
+                // Method-level emits attribute for trait default impl
+                #[contract(emits = [(OwnershipTransferred::TOPIC, OwnershipTransferred)])]
+                fn transfer_ownership(&mut self, new_owner: Address) {}
             }
         };
         let trait_impl = TraitImplInfo {
@@ -1386,5 +1626,51 @@ mod tests {
 
         let trait_impls = trait_impls(&items, "MyContract");
         assert_eq!(trait_impls.len(), 2);
+    }
+
+    // ========================================================================
+    // topic_from_expr tests
+    // ========================================================================
+
+    #[test]
+    fn test_topic_from_expr_string_literal() {
+        let expr: Expr = syn::parse_quote!("my_topic");
+        assert_eq!(topic_from_expr(&expr), Some("my_topic".to_string()));
+    }
+
+    #[test]
+    fn test_topic_from_expr_const_path() {
+        let expr: Expr = syn::parse_quote!(MyEvent::TOPIC);
+        assert_eq!(topic_from_expr(&expr), Some("MyEvent::TOPIC".to_string()));
+    }
+
+    #[test]
+    fn test_topic_from_expr_module_path() {
+        let expr: Expr = syn::parse_quote!(events::MyEvent::TOPIC);
+        assert_eq!(
+            topic_from_expr(&expr),
+            Some("events::MyEvent::TOPIC".to_string())
+        );
+    }
+
+    #[test]
+    fn test_topic_from_expr_variable() {
+        // Variable returns the variable name (warning emitted separately)
+        let expr: Expr = syn::parse_quote!(topic);
+        assert_eq!(topic_from_expr(&expr), Some("topic".to_string()));
+    }
+
+    #[test]
+    fn test_topic_from_expr_uppercase_single_ident() {
+        // Single uppercase ident is likely a const, not a variable
+        let expr: Expr = syn::parse_quote!(TOPIC);
+        assert_eq!(topic_from_expr(&expr), Some("TOPIC".to_string()));
+    }
+
+    #[test]
+    fn test_topic_from_expr_non_path_returns_none() {
+        // Non-path expressions return None
+        let expr: Expr = syn::parse_quote!(some_fn());
+        assert_eq!(topic_from_expr(&expr), None);
     }
 }

--- a/contract-macro/src/lib.rs
+++ b/contract-macro/src/lib.rs
@@ -118,6 +118,7 @@ struct FunctionInfo {
 }
 
 /// Information about an event extracted from `abi::emit()` calls.
+#[derive(Clone)]
 struct EventInfo {
     /// The event topic string.
     topic: String,
@@ -385,6 +386,20 @@ fn has_custom_attribute(attrs: &[Attribute]) -> bool {
     })
 }
 
+/// Check if method has `#[contract(no_event)]` attribute to suppress the emit
+/// validation.
+fn event_suppressed(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if attr.path().is_ident("contract")
+            && let Ok(meta) = attr.meta.require_list()
+        {
+            let tokens = meta.tokens.to_string();
+            return tokens.contains("no_event");
+        }
+        false
+    })
+}
+
 /// Extract the `feeds` type from a `#[contract(feeds = "Type")]` attribute.
 ///
 /// This attribute specifies the type fed via `abi::feed()` for streaming
@@ -522,6 +537,8 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
             Err(e) => return e.to_compile_error().into(),
         }
         events.extend(extract::emit_calls(trait_impl.impl_block));
+        // Include events from method-level #[contract(emits = [...])] attributes
+        events.extend(extract::trait_method_emits(trait_impl));
     }
 
     // Deduplicate events by topic

--- a/contract-macro/src/lib.rs
+++ b/contract-macro/src/lib.rs
@@ -528,6 +528,8 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
             Err(e) => return e.to_compile_error().into(),
         }
         events.extend(extract::emit_calls(impl_block));
+        // Include events from method-level #[contract(emits = [...])] attributes
+        events.extend(extract::inherent_method_emits(impl_block));
     }
 
     // Extract functions and events from trait impl blocks with expose lists

--- a/contract-macro/src/validate.rs
+++ b/contract-macro/src/validate.rs
@@ -362,6 +362,58 @@ pub(crate) fn trait_method(
     Ok(())
 }
 
+/// Validate that a mutating method emits events.
+///
+/// Public `&mut self` methods should emit events for observability. This
+/// validation produces a compile error if such a method doesn't emit events,
+/// unless:
+/// - The method has `#[contract(no_event)]` to explicitly suppress the check
+/// - The method has manual events registered via `#[contract(emits = [...])]`
+pub(crate) fn method_emits_event(
+    method: &ImplItemFn,
+    has_emit_call: bool,
+    suppressed: bool,
+    has_manual_events: bool,
+) -> Result<(), syn::Error> {
+    // Skip if method has #[contract(no_event)] attribute
+    if suppressed {
+        return Ok(());
+    }
+
+    // Skip if not a mutating method (&mut self)
+    let receiver = method.sig.inputs.first().and_then(|arg| {
+        if let FnArg::Receiver(r) = arg {
+            Some(r)
+        } else {
+            None
+        }
+    });
+
+    let Some(receiver) = receiver else {
+        // No self parameter - not a mutating method
+        return Ok(());
+    };
+
+    // Only check &mut self methods
+    if receiver.reference.is_none() || receiver.mutability.is_none() {
+        return Ok(());
+    }
+
+    // Check if method emits events (either directly or via manual registration)
+    if !has_emit_call && !has_manual_events {
+        return Err(syn::Error::new_spanned(
+            &method.sig,
+            format!(
+                "public method `{}` mutates state but emits no events; \
+                 add an `abi::emit()` call or suppress with `#[contract(no_event)]`",
+                method.sig.ident
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -773,5 +825,69 @@ mod tests {
             msg.contains("return type"),
             "error should mention return type: {msg}"
         );
+    }
+
+    // ========================================================================
+    // method_emits_event tests
+    // ========================================================================
+
+    #[test]
+    fn test_method_emits_event_ref_self_no_emit_ok() {
+        // &self methods don't need to emit events
+        let method: ImplItemFn = syn::parse_quote! {
+            pub fn get_value(&self) -> u64 { 0 }
+        };
+        assert!(method_emits_event(&method, false, false, false).is_ok());
+    }
+
+    #[test]
+    fn test_method_emits_event_mut_self_with_emit_ok() {
+        let method: ImplItemFn = syn::parse_quote! {
+            pub fn set_value(&mut self, value: u64) { }
+        };
+        assert!(method_emits_event(&method, true, false, false).is_ok());
+    }
+
+    #[test]
+    fn test_method_emits_event_mut_self_no_emit_error() {
+        let method: ImplItemFn = syn::parse_quote! {
+            pub fn set_value(&mut self, value: u64) { }
+        };
+        let err = method_emits_event(&method, false, false, false).unwrap_err();
+        assert!(err.to_string().contains("emits no events"));
+    }
+
+    #[test]
+    fn test_method_emits_event_mut_self_no_emit_suppressed() {
+        let method: ImplItemFn = syn::parse_quote! {
+            pub fn set_value(&mut self, value: u64) { }
+        };
+        assert!(method_emits_event(&method, false, true, false).is_ok());
+    }
+
+    #[test]
+    fn test_method_emits_event_mut_self_with_manual_events() {
+        let method: ImplItemFn = syn::parse_quote! {
+            pub fn set_value(&mut self, value: u64) { }
+        };
+        assert!(method_emits_event(&method, false, false, true).is_ok());
+    }
+
+    #[test]
+    fn test_method_emits_event_no_receiver_ok() {
+        // Associated function (no self) doesn't need emit
+        let method: ImplItemFn = syn::parse_quote! {
+            pub fn default_value() -> u64 { 0 }
+        };
+        assert!(method_emits_event(&method, false, false, false).is_ok());
+    }
+
+    #[test]
+    fn test_method_emits_event_consuming_self_ok() {
+        // Consuming self (not &mut self) doesn't need emit check
+        let method: ImplItemFn = syn::parse_quote! {
+            pub fn into_value(self) -> u64 { 0 }
+        };
+        assert!(method_emits_event(&method, false, false, false).is_ok());
     }
 }

--- a/tests/test-contract/src/lib.rs
+++ b/tests/test-contract/src/lib.rs
@@ -30,7 +30,7 @@ mod test_contract {
 
     use dusk_core::abi;
     use dusk_core::signatures::bls::PublicKey;
-    use types::{Item, ItemId, Ownable, events};
+    use types::{Item, ItemId, Ownable, events, helpers};
 
     // =========================================================================
     // Versioned trait — tests trait-exposed associated function (no self)
@@ -142,6 +142,18 @@ mod test_contract {
         /// Exercises: associated function (no self).
         pub fn empty_id() -> ItemId {
             ItemId(0)
+        }
+
+        /// Bumps the tally by delegating to a free helper function.
+        ///
+        /// Exercises `#[contract(emits = [...])]` on an inherent method: the
+        /// actual `abi::emit` call lives in `helpers::emit_tally_bumped`,
+        /// outside any contract impl block, so the macro's body scanner
+        /// cannot see it.
+        #[contract(emits = [(events::TallyBumped::TOPIC, events::TallyBumped)])]
+        pub fn bump_tally(&mut self) {
+            self.counter += 1;
+            helpers::emit_tally_bumped();
         }
     }
 

--- a/tests/test-contract/src/lib.rs
+++ b/tests/test-contract/src/lib.rs
@@ -74,6 +74,10 @@ mod test_contract {
         }
 
         /// Initializes the contract with an owner.
+        ///
+        /// This method intentionally doesn't emit an event as it's only called
+        /// during contract deployment.
+        #[contract(no_event)]
         pub fn init(&mut self, owner: PublicKey) {
             self.owner = Some(owner);
         }
@@ -216,7 +220,9 @@ mod test_contract {
     /// contract functions; `owner_mut` and `only_owner` remain internal.
     ///
     /// Empty method bodies signal the macro to use the trait's default
-    /// implementations.
+    /// implementations. The `emits` attribute on methods registers events
+    /// that are emitted by trait default implementations (not visible in
+    /// the impl block body).
     #[contract(expose = [owner, transfer_ownership, renounce_ownership])]
     #[allow(clippy::unused_self, clippy::needless_pass_by_value)]
     impl Ownable for TestContract {
@@ -233,11 +239,13 @@ mod test_contract {
         /// Transfers ownership to a new public key.
         /// Empty body signals the macro to use the trait's default
         /// implementation.
+        #[contract(emits = [(events::OwnershipTransferred::TRANSFERRED, events::OwnershipTransferred)])]
         fn transfer_ownership(&mut self, new_owner: PublicKey) {}
 
         /// Renounces ownership of the contract.
         /// Empty body signals the macro to use the trait's default
         /// implementation.
+        #[contract(emits = [(events::OwnershipTransferred::RENOUNCED, events::OwnershipTransferred)])]
         fn renounce_ownership(&mut self) {}
     }
 

--- a/tests/test-contract/tests/contract.rs
+++ b/tests/test-contract/tests/contract.rs
@@ -15,16 +15,72 @@ extern crate alloc;
 
 use std::sync::{LazyLock, mpsc};
 
-use dusk_core::abi::ContractId;
+use dusk_core::abi::{ContractError, ContractId, StandardBufSerializer};
 use dusk_core::dusk;
 use dusk_core::signatures::bls::{PublicKey as AccountPublicKey, SecretKey as AccountSecretKey};
-use dusk_vm::CallReceipt;
+use dusk_vm::{CallReceipt, Error as VMError};
+use rkyv::bytecheck::CheckBytes;
+use rkyv::validation::validators::DefaultValidator;
+use rkyv::{Archive, Deserialize, Infallible, Serialize};
 mod test_session;
 
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use test_session::TestSession;
 use types::{Item, ItemId};
+
+/// Direct/feeder call helpers used only by this test binary.
+///
+/// Lives here (not in `test_session.rs`) so the schema test binary, which
+/// only needs the public-call path, doesn't trip a `dead_code` warning.
+impl TestSession {
+    /// Directly calls the contract, circumventing the transfer contract and
+    /// (among other things) also any gas-payment.
+    fn direct_call<A, R>(
+        &mut self,
+        contract: ContractId,
+        fn_name: &str,
+        fn_arg: &A,
+    ) -> Result<CallReceipt<R>, ContractError>
+    where
+        A: for<'b> Serialize<StandardBufSerializer<'b>>,
+        A::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,
+        R: Archive,
+        R::Archived: Deserialize<R, Infallible> + for<'b> CheckBytes<DefaultValidator<'b>>,
+    {
+        self.0
+            .call::<_, R>(contract, fn_name, fn_arg, u64::MAX)
+            .map_err(|e| match e {
+                VMError::Panic(panic_msg) => ContractError::Panic(panic_msg),
+                VMError::OutOfGas => ContractError::OutOfGas,
+                _ => panic!("Unknown error: {e}"),
+            })
+    }
+
+    /// Feeder calls let the contract report larger amounts of data to the
+    /// host via the channel included in this call.
+    fn feeder_call<A, R>(
+        &mut self,
+        contract: ContractId,
+        fn_name: &str,
+        fn_arg: &A,
+        feeder: std::sync::mpsc::Sender<Vec<u8>>,
+    ) -> Result<CallReceipt<R>, ContractError>
+    where
+        A: for<'b> Serialize<StandardBufSerializer<'b>>,
+        A::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,
+        R: Archive,
+        R::Archived: Deserialize<R, Infallible> + for<'b> CheckBytes<DefaultValidator<'b>>,
+    {
+        self.0
+            .feeder_call::<_, R>(contract, fn_name, fn_arg, u64::MAX, feeder)
+            .map_err(|e| match e {
+                VMError::Panic(panic_msg) => ContractError::Panic(panic_msg),
+                VMError::OutOfGas => ContractError::OutOfGas,
+                _ => panic!("Unknown error: {e}"),
+            })
+    }
+}
 
 const DEPLOYER: [u8; 64] = [0u8; 64];
 

--- a/tests/test-contract/tests/contract.rs
+++ b/tests/test-contract/tests/contract.rs
@@ -118,6 +118,12 @@ impl TestContractSession {
             .expect("renounce_ownership should succeed")
     }
 
+    fn bump_tally(&mut self, sender_sk: &AccountSecretKey) -> CallReceipt<()> {
+        self.session
+            .call_public(sender_sk, CONTRACT_ID, "bump_tally", &())
+            .expect("bump_tally should succeed")
+    }
+
     // Mutating methods
 
     fn set_counter(&mut self, sender_sk: &AccountSecretKey, value: u64) -> CallReceipt<()> {
@@ -245,6 +251,25 @@ fn test_renounce_ownership() {
     assert!(
         !receipt.events.is_empty(),
         "renounce_ownership should emit an event"
+    );
+}
+
+/// `bump_tally` is an inherent method with `#[contract(emits = [...])]`; the
+/// actual `abi::emit` call happens in `emit_tally_bumped`, a free helper
+/// outside any contract impl block, so it is invisible to the macro's body
+/// scanner. Verify the call still succeeds and the delegated event is
+/// emitted at runtime.
+#[test]
+fn test_delegating_inherent_method_emits_event() {
+    let mut session = TestContractSession::new();
+
+    let receipt = session.bump_tally(&OWNER_SK);
+
+    let tally_event = receipt.events.iter().find(|e| e.topic == "tally_bumped");
+    assert!(
+        tally_event.is_some(),
+        "bump_tally should emit tally_bumped via helper; got: {:?}",
+        receipt.events
     );
 }
 

--- a/tests/test-contract/tests/schema.rs
+++ b/tests/test-contract/tests/schema.rs
@@ -157,6 +157,34 @@ fn test_schema_has_events() {
     );
 }
 
+/// Verify that `#[contract(emits = [...])]` on an inherent method registers
+/// events emitted by a helper outside the impl block.
+///
+/// `bump_tally` is an inherent method that delegates to `emit_tally_bumped`,
+/// a free function where the actual `abi::emit` call lives. The macro's body
+/// scanner cannot see that call, so the author declares the event via
+/// `emits`. The registered event must appear in the schema.
+#[test]
+fn test_schema_has_delegated_inherent_event() {
+    let schema_json = get_schema_from_wasm();
+    let schema: serde_json::Value =
+        serde_json::from_str(&schema_json).expect("Failed to parse schema JSON");
+
+    let events = schema["events"]
+        .as_array()
+        .expect("events should be an array");
+    let event_topics: Vec<&str> = events
+        .iter()
+        .map(|e| e["topic"].as_str().unwrap())
+        .collect();
+
+    assert!(
+        event_topics.iter().any(|t| t.contains("TallyBumped")),
+        "missing TallyBumped event from inherent emits attribute; \
+         topics: {event_topics:?}"
+    );
+}
+
 /// Verify that manually registered events via `#[contract(emits = [...])]`
 /// appear in the schema.
 ///

--- a/tests/test-contract/tests/schema.rs
+++ b/tests/test-contract/tests/schema.rs
@@ -157,6 +157,41 @@ fn test_schema_has_events() {
     );
 }
 
+/// Verify that manually registered events via `#[contract(emits = [...])]`
+/// appear in the schema.
+///
+/// The `Ownable` trait impl uses the `emits` attribute on methods to register
+/// ownership events that are emitted by the trait's default implementations
+/// (which the macro can't see since they have empty bodies in our impl block).
+#[test]
+fn test_schema_has_ownership_events() {
+    let schema_json = get_schema_from_wasm();
+    let schema: serde_json::Value =
+        serde_json::from_str(&schema_json).expect("Failed to parse schema JSON");
+
+    let events = schema["events"]
+        .as_array()
+        .expect("events should be an array");
+    let event_topics: Vec<&str> = events
+        .iter()
+        .map(|e| e["topic"].as_str().unwrap())
+        .collect();
+
+    // Check for ownership events registered via emits attribute.
+    // Topics are stored as const path strings
+    // (e.g., "events::OwnershipTransferred::TRANSFERRED").
+    assert!(
+        event_topics.iter().any(|t| t.contains("TRANSFERRED")),
+        "missing ownership transferred event from emits attribute; \
+         topics: {event_topics:?}"
+    );
+    assert!(
+        event_topics.iter().any(|t| t.contains("RENOUNCED")),
+        "missing ownership renounced event from emits attribute; \
+         topics: {event_topics:?}"
+    );
+}
+
 #[test]
 fn test_schema_has_imports() {
     let schema_json = get_schema_from_wasm();

--- a/tests/test-contract/tests/test_session.rs
+++ b/tests/test-contract/tests/test_session.rs
@@ -50,7 +50,6 @@ const CONFIG: ExecutionConfig = ExecutionConfig {
 /// like a mainnet VM.
 pub struct TestSession(pub Session);
 
-#[allow(dead_code)]
 impl TestSession {
     /// Passes the call to deploy bytecode of a contract to the
     /// underlying session with maximum gas limit.
@@ -77,53 +76,6 @@ impl TestSession {
         self.0
             .call(TRANSFER_CONTRACT, "account", pk, GAS_LIMIT)
             .map(|r| r.data)
-    }
-
-    /// Directly calls the contract, circumventing the transfer contract and
-    /// (among other things) also any gas-payment.
-    pub fn direct_call<A, R>(
-        &mut self,
-        contract: ContractId,
-        fn_name: &str,
-        fn_arg: &A,
-    ) -> Result<CallReceipt<R>, ContractError>
-    where
-        A: for<'b> Serialize<StandardBufSerializer<'b>>,
-        A::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,
-        R: Archive,
-        R::Archived: Deserialize<R, Infallible> + for<'b> CheckBytes<DefaultValidator<'b>>,
-    {
-        self.0
-            .call::<_, R>(contract, fn_name, fn_arg, u64::MAX)
-            .map_err(|e| match e {
-                VMError::Panic(panic_msg) => ContractError::Panic(panic_msg),
-                VMError::OutOfGas => ContractError::OutOfGas,
-                _ => panic!("Unknown error: {e}"),
-            })
-    }
-
-    /// Feeder calls are used to have the contract be able to report larger
-    /// amounts of data to the host via the channel included in this call.
-    pub fn feeder_call<A, R>(
-        &mut self,
-        contract: ContractId,
-        fn_name: &str,
-        fn_arg: &A,
-        feeder: std::sync::mpsc::Sender<Vec<u8>>,
-    ) -> Result<CallReceipt<R>, ContractError>
-    where
-        A: for<'b> Serialize<StandardBufSerializer<'b>>,
-        A::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,
-        R: Archive,
-        R::Archived: Deserialize<R, Infallible> + for<'b> CheckBytes<DefaultValidator<'b>>,
-    {
-        self.0
-            .feeder_call::<_, R>(contract, fn_name, fn_arg, u64::MAX, feeder)
-            .map_err(|e| match e {
-                VMError::Panic(panic_msg) => ContractError::Panic(panic_msg),
-                VMError::OutOfGas => ContractError::OutOfGas,
-                _ => panic!("Unknown error: {e}"),
-            })
     }
 
     /// Calls the contract through the transfer-contract which is the standard
@@ -336,24 +288,4 @@ where
     let pos = ser.pos();
 
     buffer[..pos].to_vec()
-}
-
-#[allow(dead_code)]
-pub fn assert_contract_panic<R>(
-    call_result: Result<CallReceipt<R>, ContractError>,
-    expected_panic: &str,
-) where
-    R: Archive,
-    R::Archived: Deserialize<R, Infallible> + for<'b> CheckBytes<DefaultValidator<'b>>,
-{
-    let contract_err = match call_result {
-        Ok(_) => panic!("Contract call shouldn't pass"),
-        Err(error) => error,
-    };
-
-    if let ContractError::Panic(panic_msg) = contract_err {
-        assert_eq!(panic_msg, expected_panic);
-    } else {
-        panic!("Expected contract panic, got error: {contract_err}",);
-    }
 }

--- a/tests/types/src/lib.rs
+++ b/tests/types/src/lib.rs
@@ -141,6 +141,7 @@ pub mod events {
 
     /// Event emitted when ownership is transferred or renounced.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Archive, Serialize, Deserialize)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[archive_attr(derive(CheckBytes))]
     pub struct OwnershipTransferred {
         /// The previous owner.

--- a/tests/types/src/lib.rs
+++ b/tests/types/src/lib.rs
@@ -102,6 +102,23 @@ pub trait Ownable {
 }
 
 // =========================================================================
+// Helpers module
+// =========================================================================
+
+/// Free helper functions that emit events from outside any contract impl
+/// block. Used by the test contract to exercise `#[contract(emits = [...])]`
+/// on inherent methods that delegate work to non-contract code.
+#[cfg(feature = "abi")]
+pub mod helpers {
+    use crate::events;
+
+    /// Emits an [`events::TallyBumped`] event.
+    pub fn emit_tally_bumped() {
+        dusk_core::abi::emit(events::TallyBumped::TOPIC, events::TallyBumped());
+    }
+}
+
+// =========================================================================
 // Events module
 // =========================================================================
 
@@ -165,6 +182,17 @@ pub mod events {
         pub const ADDED: &'static str = "item_added";
         /// Event topic for removing an item.
         pub const REMOVED: &'static str = "item_removed";
+    }
+
+    /// Event emitted by [`super::helpers::emit_tally_bumped`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Archive, Serialize, Deserialize)]
+    #[archive_attr(derive(CheckBytes))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    pub struct TallyBumped();
+
+    impl TallyBumped {
+        /// Event topic for tally bumps.
+        pub const TOPIC: &'static str = "tally_bumped";
     }
 
     /// Event emitted when the contract is updated with new counter and label.


### PR DESCRIPTION
## Summary

Add manual event registration for the `#[contract]` macro via three related features:

- **`#[contract(emits = [...])]`** — method-level attribute that declares events emitted by trait default implementations (invisible to the macro's body scanner). Events listed in `emits` are included in the contract schema alongside those discovered from `abi::emit()` calls.
- **Compile error for silent mutations** — public `&mut self` methods must now emit events or declare them via `emits`. Use `#[contract(no_event)]` to suppress the check for methods like `init` that intentionally skip emission.
- **Variable topic detection** — detects lowercase single-segment identifiers used as `abi::emit()` topics (likely variables whose runtime value the macro can't capture). Warning is a no-op on stable Rust pending `proc_macro_diagnostic` stabilisation.

Stacks on #17.