### PR TITLE
Forge: remove custom data-driver handler feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make `dusk-forge build data-driver` select the supported project feature (`data-driver-js` or `data-driver`) instead of hardcoding the JS variant.
 
+### Removed
+
+- Drop the custom data-driver handler escape hatch (`#[contract(custom)]` and the `encode_input` / `decode_input` / `decode_output` attributes). The feature had no production consumers and was the source of recurring macro bugs caused by user code being moved out of its original module and losing its resolution context. Default `rkyv` / JSON codegen is now the only path.
+
 ## [0.2.2] - 2026-02-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -205,29 +205,6 @@ The data-driver WASM exports these functions:
 
 For JavaScript integration, use [w3sper](https://github.com/dusk-network/rusk/tree/master/w3sper.js) which provides a high-level API for working with data-drivers.
 
-### Custom Serialization
-
-For types requiring custom encoding/decoding:
-
-```rust
-#[contract]
-mod my_contract {
-    // ... contract impl ...
-
-    /// Custom encoder for the "special_data" function.
-    #[contract(encode_input = "special_data")]
-    fn encode_special(json: &str) -> Result<alloc::vec::Vec<u8>, dusk_data_driver::Error> {
-        // Custom encoding logic
-    }
-
-    /// Custom decoder for the "special_data" function.
-    #[contract(decode_output = "special_data")]
-    fn decode_special(rkyv: &[u8]) -> Result<dusk_data_driver::JsonValue, dusk_data_driver::Error> {
-        // Custom decoding logic
-    }
-}
-```
-
 ## Contract Schema
 
 The macro generates a `CONTRACT_SCHEMA` constant with metadata:

--- a/contract-macro/src/data_driver.rs
+++ b/contract-macro/src/data_driver.rs
@@ -17,22 +17,18 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
 use crate::resolve::TypeMap;
-use crate::{CustomDataDriverHandler, DataDriverRole, EventInfo, FunctionInfo};
+use crate::{EventInfo, FunctionInfo};
 
 /// Generate the `data_driver` module at crate root level.
 pub(crate) fn module(
     type_map: &TypeMap,
     functions: &[FunctionInfo],
     events: &[EventInfo],
-    custom_handlers: &[CustomDataDriverHandler],
 ) -> TokenStream2 {
-    let encode_input_arms = generate_encode_input_arms(functions, type_map, custom_handlers);
-    let decode_input_arms = generate_decode_input_arms(functions, type_map, custom_handlers);
-    let decode_output_arms = generate_decode_output_arms(functions, type_map, custom_handlers);
+    let encode_input_arms = generate_encode_input_arms(functions, type_map);
+    let decode_input_arms = generate_decode_input_arms(functions, type_map);
+    let decode_output_arms = generate_decode_output_arms(functions, type_map);
     let decode_event_arms = generate_decode_event_arms(events, type_map);
-
-    // Collect custom handler functions to include in the module
-    let custom_handler_fns: Vec<_> = custom_handlers.iter().map(|h| &h.func).collect();
 
     quote! {
         /// Auto-generated data driver module.
@@ -45,9 +41,6 @@ pub(crate) fn module(
             use alloc::format;
             use alloc::string::String;
             use alloc::vec::Vec;
-
-            // Custom handler functions moved from the contract module
-            #(#custom_handler_fns)*
 
             /// Auto-generated contract driver.
             #[derive(Default)]
@@ -135,83 +128,31 @@ fn get_resolved_type(ty: &TokenStream2, type_map: &TypeMap) -> TokenStream2 {
 }
 
 /// Generate match arms for `encode_input_fn`.
-fn generate_encode_input_arms(
-    functions: &[FunctionInfo],
-    type_map: &TypeMap,
-    custom_handlers: &[CustomDataDriverHandler],
-) -> Vec<TokenStream2> {
-    let mut arms: Vec<TokenStream2> = functions
+fn generate_encode_input_arms(functions: &[FunctionInfo], type_map: &TypeMap) -> Vec<TokenStream2> {
+    functions
         .iter()
         .map(|f| {
             let name_str = f.name.to_string();
             let input_type = get_resolved_type(&f.input_type, type_map);
-
-            if f.is_custom {
-                quote! {
-                    #name_str => Err(dusk_data_driver::Error::Unsupported(
-                        alloc::format!("custom handler required: {}", #name_str)
-                    ))
-                }
-            } else {
-                quote! {
-                    #name_str => dusk_data_driver::json_to_rkyv::<#input_type>(json)
-                }
+            quote! {
+                #name_str => dusk_data_driver::json_to_rkyv::<#input_type>(json)
             }
         })
-        .collect();
-
-    // Add custom handler arms
-    for handler in custom_handlers {
-        if handler.role == DataDriverRole::EncodeInput {
-            let fn_name_str = &handler.fn_name;
-            let handler_fn_name = &handler.func.sig.ident;
-            arms.push(quote! {
-                #fn_name_str => #handler_fn_name(json)
-            });
-        }
-    }
-
-    arms
+        .collect()
 }
 
 /// Generate match arms for `decode_input_fn`.
-fn generate_decode_input_arms(
-    functions: &[FunctionInfo],
-    type_map: &TypeMap,
-    custom_handlers: &[CustomDataDriverHandler],
-) -> Vec<TokenStream2> {
-    let mut arms: Vec<TokenStream2> = functions
+fn generate_decode_input_arms(functions: &[FunctionInfo], type_map: &TypeMap) -> Vec<TokenStream2> {
+    functions
         .iter()
         .map(|f| {
             let name_str = f.name.to_string();
             let input_type = get_resolved_type(&f.input_type, type_map);
-
-            if f.is_custom {
-                quote! {
-                    #name_str => Err(dusk_data_driver::Error::Unsupported(
-                        alloc::format!("custom handler required: {}", #name_str)
-                    ))
-                }
-            } else {
-                quote! {
-                    #name_str => dusk_data_driver::rkyv_to_json::<#input_type>(rkyv)
-                }
+            quote! {
+                #name_str => dusk_data_driver::rkyv_to_json::<#input_type>(rkyv)
             }
         })
-        .collect();
-
-    // Add custom handler arms
-    for handler in custom_handlers {
-        if handler.role == DataDriverRole::DecodeInput {
-            let fn_name_str = &handler.fn_name;
-            let handler_fn_name = &handler.func.sig.ident;
-            arms.push(quote! {
-                #fn_name_str => #handler_fn_name(rkyv)
-            });
-        }
-    }
-
-    arms
+        .collect()
 }
 
 /// Generate match arms for `decode_output_fn`.
@@ -222,9 +163,8 @@ fn generate_decode_input_arms(
 fn generate_decode_output_arms(
     functions: &[FunctionInfo],
     type_map: &TypeMap,
-    custom_handlers: &[CustomDataDriverHandler],
 ) -> Vec<TokenStream2> {
-    let mut arms: Vec<TokenStream2> = functions
+    functions
         .iter()
         .map(|f| {
             let name_str = f.name.to_string();
@@ -242,13 +182,7 @@ fn generate_decode_output_arms(
                 )
             };
 
-            if f.is_custom {
-                quote! {
-                    #name_str => Err(dusk_data_driver::Error::Unsupported(
-                        alloc::format!("custom handler required: {}", #name_str)
-                    ))
-                }
-            } else if type_str == "()" {
+            if type_str == "()" {
                 quote! {
                     #name_str => Ok(dusk_data_driver::JsonValue::Null)
                 }
@@ -262,20 +196,7 @@ fn generate_decode_output_arms(
                 }
             }
         })
-        .collect();
-
-    // Add custom handler arms
-    for handler in custom_handlers {
-        if handler.role == DataDriverRole::DecodeOutput {
-            let fn_name_str = &handler.fn_name;
-            let handler_fn_name = &handler.func.sig.ident;
-            arms.push(quote! {
-                #fn_name_str => #handler_fn_name(rkyv)
-            });
-        }
-    }
-
-    arms
+        .collect()
 }
 
 /// Generate match arms for `decode_event`.
@@ -332,19 +253,13 @@ mod tests {
     }
 
     /// Create a basic `FunctionInfo` for testing.
-    fn make_function(
-        name: &str,
-        input: TokenStream2,
-        output: TokenStream2,
-        is_custom: bool,
-    ) -> FunctionInfo {
+    fn make_function(name: &str, input: TokenStream2, output: TokenStream2) -> FunctionInfo {
         FunctionInfo {
             name: format_ident!("{}", name),
             doc: None,
             params: vec![],
             input_type: input,
             output_type: output,
-            is_custom,
             returns_ref: false,
             receiver: Receiver::Ref,
             trait_name: None,
@@ -357,27 +272,6 @@ mod tests {
         EventInfo {
             topic: topic.to_string(),
             data_type,
-        }
-    }
-
-    /// Create a `CustomDataDriverHandler` for testing.
-    fn make_custom_handler(
-        fn_name: &str,
-        role: DataDriverRole,
-        handler_name: &str,
-    ) -> CustomDataDriverHandler {
-        // Build the function using the handler_name identifier
-        let handler_ident = format_ident!("{}", handler_name);
-        let func: syn::ItemFn = syn::parse_quote! {
-            fn #handler_ident(_input: &str) -> Result<Vec<u8>, Error> {
-                Ok(vec![])
-            }
-        };
-
-        CustomDataDriverHandler {
-            fn_name: fn_name.to_string(),
-            role,
-            func,
         }
     }
 
@@ -426,13 +320,8 @@ mod tests {
         let mut type_map = HashMap::new();
         type_map.insert("Address".to_string(), "my_crate::Address".to_string());
 
-        let functions = vec![make_function(
-            "init",
-            quote! { Address },
-            quote! { () },
-            false,
-        )];
-        let arms = generate_encode_input_arms(&functions, &type_map, &[]);
+        let functions = vec![make_function("init", quote! { Address }, quote! { () })];
+        let arms = generate_encode_input_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -448,13 +337,8 @@ mod tests {
     fn test_encode_input_unit_type() {
         let type_map = HashMap::new();
 
-        let functions = vec![make_function(
-            "is_paused",
-            quote! { () },
-            quote! { bool },
-            false,
-        )];
-        let arms = generate_encode_input_arms(&functions, &type_map, &[]);
+        let functions = vec![make_function("is_paused", quote! { () }, quote! { bool })];
+        let arms = generate_encode_input_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -475,9 +359,8 @@ mod tests {
             "transfer",
             quote! { (Address, u64) },
             quote! { () },
-            false,
         )];
-        let arms = generate_encode_input_arms(&functions, &type_map, &[]);
+        let arms = generate_encode_input_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -492,55 +375,15 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_input_custom_returns_error() {
-        let type_map = HashMap::new();
-
-        let functions = vec![make_function(
-            "custom_fn",
-            quote! { CustomType },
-            quote! { Vec<u8> },
-            true, // is_custom = true
-        )];
-        let arms = generate_encode_input_arms(&functions, &type_map, &[]);
-
-        assert_eq!(arms.len(), 1);
-        let arm_str = normalize_tokens(arms[0].clone());
-        assert!(arm_str.contains("\"custom_fn\""));
-        assert!(arm_str.contains("Err"));
-        assert!(arm_str.contains("Unsupported"));
-        assert!(arm_str.contains("custom handler required"));
-    }
-
-    #[test]
-    fn test_encode_input_with_custom_handler() {
-        let type_map = HashMap::new();
-        let functions = vec![]; // No regular functions
-
-        let custom_handlers = vec![make_custom_handler(
-            "extra_data",
-            DataDriverRole::EncodeInput,
-            "encode_extra_data",
-        )];
-
-        let arms = generate_encode_input_arms(&functions, &type_map, &custom_handlers);
-
-        assert_eq!(arms.len(), 1);
-        let arm_str = normalize_tokens(arms[0].clone());
-        assert!(arm_str.contains("\"extra_data\""));
-        assert!(arm_str.contains("encode_extra_data"));
-        assert!(arm_str.contains("(json)"));
-    }
-
-    #[test]
     fn test_encode_input_multiple_functions() {
         let type_map = HashMap::new();
 
         let functions = vec![
-            make_function("pause", quote! { () }, quote! { () }, false),
-            make_function("unpause", quote! { () }, quote! { () }, false),
-            make_function("init", quote! { Address }, quote! { () }, false),
+            make_function("pause", quote! { () }, quote! { () }),
+            make_function("unpause", quote! { () }, quote! { () }),
+            make_function("init", quote! { Address }, quote! { () }),
         ];
-        let arms = generate_encode_input_arms(&functions, &type_map, &[]);
+        let arms = generate_encode_input_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 3);
 
@@ -560,57 +403,14 @@ mod tests {
         let mut type_map = HashMap::new();
         type_map.insert("Deposit".to_string(), "my_crate::Deposit".to_string());
 
-        let functions = vec![make_function(
-            "deposit",
-            quote! { Deposit },
-            quote! { () },
-            false,
-        )];
-        let arms = generate_decode_input_arms(&functions, &type_map, &[]);
+        let functions = vec![make_function("deposit", quote! { Deposit }, quote! { () })];
+        let arms = generate_decode_input_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
         assert!(arm_str.contains("\"deposit\""));
         assert!(arm_str.contains("rkyv_to_json"));
         assert!(arm_str.contains("my_crate :: Deposit"));
-    }
-
-    #[test]
-    fn test_decode_input_custom_returns_error() {
-        let type_map = HashMap::new();
-
-        let functions = vec![make_function(
-            "custom_fn",
-            quote! { CustomType },
-            quote! { () },
-            true,
-        )];
-        let arms = generate_decode_input_arms(&functions, &type_map, &[]);
-
-        assert_eq!(arms.len(), 1);
-        let arm_str = normalize_tokens(arms[0].clone());
-        assert!(arm_str.contains("Err"));
-        assert!(arm_str.contains("custom handler required"));
-    }
-
-    #[test]
-    fn test_decode_input_with_custom_handler() {
-        let type_map = HashMap::new();
-        let functions = vec![];
-
-        let custom_handlers = vec![make_custom_handler(
-            "extra_data",
-            DataDriverRole::DecodeInput,
-            "decode_extra_input",
-        )];
-
-        let arms = generate_decode_input_arms(&functions, &type_map, &custom_handlers);
-
-        assert_eq!(arms.len(), 1);
-        let arm_str = normalize_tokens(arms[0].clone());
-        assert!(arm_str.contains("\"extra_data\""));
-        assert!(arm_str.contains("decode_extra_input"));
-        assert!(arm_str.contains("(rkyv)"));
     }
 
     #[test]
@@ -626,9 +426,8 @@ mod tests {
             "transfer_with_fee",
             quote! { (Address, MyAddr, u64) },
             quote! { () },
-            false,
         )];
-        let arms = generate_decode_input_arms(&functions, &type_map, &[]);
+        let arms = generate_decode_input_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -647,137 +446,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_custom_handler_wrong_role_not_included_in_encode() {
-        let type_map = HashMap::new();
-        let functions = vec![];
-
-        // DecodeOutput handler should NOT appear in encode_input_arms
-        let custom_handlers = vec![make_custom_handler(
-            "extra_data",
-            DataDriverRole::DecodeOutput,
-            "decode_extra_output",
-        )];
-
-        let arms = generate_encode_input_arms(&functions, &type_map, &custom_handlers);
-
-        assert_eq!(
-            arms.len(),
-            0,
-            "DecodeOutput handler should not appear in encode_input_arms"
-        );
-    }
-
-    #[test]
-    fn test_custom_handler_wrong_role_not_included_in_decode_input() {
-        let type_map = HashMap::new();
-        let functions = vec![];
-
-        // EncodeInput handler should NOT appear in decode_input_arms
-        let custom_handlers = vec![make_custom_handler(
-            "extra_data",
-            DataDriverRole::EncodeInput,
-            "encode_extra_data",
-        )];
-
-        let arms = generate_decode_input_arms(&functions, &type_map, &custom_handlers);
-
-        assert_eq!(
-            arms.len(),
-            0,
-            "EncodeInput handler should not appear in decode_input_arms"
-        );
-    }
-
-    #[test]
-    fn test_custom_handler_wrong_role_not_included_in_decode_output() {
-        let type_map = HashMap::new();
-        let functions = vec![];
-
-        // DecodeInput handler should NOT appear in decode_output_arms
-        let custom_handlers = vec![make_custom_handler(
-            "extra_data",
-            DataDriverRole::DecodeInput,
-            "decode_extra_input",
-        )];
-
-        let arms = generate_decode_output_arms(&functions, &type_map, &custom_handlers);
-
-        assert_eq!(
-            arms.len(),
-            0,
-            "DecodeInput handler should not appear in decode_output_arms"
-        );
-    }
-
-    #[test]
-    fn test_encode_input_mixed_regular_and_custom() {
-        let mut type_map = HashMap::new();
-        type_map.insert("Address".to_string(), "my_crate::Address".to_string());
-
-        let functions = vec![
-            make_function("init", quote! { Address }, quote! { () }, false),
-            make_function("is_paused", quote! { () }, quote! { bool }, false),
-        ];
-
-        let custom_handlers = vec![make_custom_handler(
-            "extra_data",
-            DataDriverRole::EncodeInput,
-            "encode_extra_data",
-        )];
-
-        let arms = generate_encode_input_arms(&functions, &type_map, &custom_handlers);
-
-        // Should have 2 regular functions + 1 custom handler
-        assert_eq!(arms.len(), 3);
-
-        let all_arms: String = arms.iter().map(|a| normalize_tokens(a.clone())).collect();
-
-        // Verify regular functions use json_to_rkyv
-        assert!(all_arms.contains("\"init\""));
-        assert!(all_arms.contains("\"is_paused\""));
-        assert!(all_arms.contains("json_to_rkyv"));
-
-        // Verify custom handler calls the handler function
-        assert!(all_arms.contains("\"extra_data\""));
-        assert!(all_arms.contains("encode_extra_data (json)"));
-    }
-
-    #[test]
-    fn test_decode_output_mixed_regular_and_custom() {
-        let type_map = HashMap::new();
-
-        let functions = vec![
-            make_function("pause", quote! { () }, quote! { () }, false),
-            make_function("get_value", quote! { () }, quote! { u64 }, false),
-        ];
-
-        let custom_handlers = vec![make_custom_handler(
-            "extra_data",
-            DataDriverRole::DecodeOutput,
-            "decode_extra_output",
-        )];
-
-        let arms = generate_decode_output_arms(&functions, &type_map, &custom_handlers);
-
-        // Should have 2 regular functions + 1 custom handler
-        assert_eq!(arms.len(), 3);
-
-        let all_arms: String = arms.iter().map(|a| normalize_tokens(a.clone())).collect();
-
-        // Verify pause returns Null (unit type)
-        assert!(all_arms.contains("\"pause\""));
-        assert!(all_arms.contains("JsonValue :: Null"));
-
-        // Verify get_value uses u64 special handler
-        assert!(all_arms.contains("\"get_value\""));
-        assert!(all_arms.contains("rkyv_to_json_u64"));
-
-        // Verify custom handler calls the handler function
-        assert!(all_arms.contains("\"extra_data\""));
-        assert!(all_arms.contains("decode_extra_output (rkyv)"));
-    }
-
     // =========================================================================
     // generate_decode_output_arms tests
     // =========================================================================
@@ -786,8 +454,8 @@ mod tests {
     fn test_decode_output_unit_returns_null() {
         let type_map = HashMap::new();
 
-        let functions = vec![make_function("pause", quote! { () }, quote! { () }, false)];
-        let arms = generate_decode_output_arms(&functions, &type_map, &[]);
+        let functions = vec![make_function("pause", quote! { () }, quote! { () })];
+        let arms = generate_decode_output_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -809,9 +477,8 @@ mod tests {
             "finalization_period",
             quote! { () },
             quote! { u64 },
-            false,
         )];
-        let arms = generate_decode_output_arms(&functions, &type_map, &[]);
+        let arms = generate_decode_output_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -828,13 +495,8 @@ mod tests {
     fn test_decode_output_bool() {
         let type_map = HashMap::new();
 
-        let functions = vec![make_function(
-            "is_paused",
-            quote! { () },
-            quote! { bool },
-            false,
-        )];
-        let arms = generate_decode_output_arms(&functions, &type_map, &[]);
+        let functions = vec![make_function("is_paused", quote! { () }, quote! { bool })];
+        let arms = generate_decode_output_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -857,9 +519,8 @@ mod tests {
             "pending_withdrawal",
             quote! { ItemId },
             quote! { Option<PendingItem> },
-            false,
         )];
-        let arms = generate_decode_output_arms(&functions, &type_map, &[]);
+        let arms = generate_decode_output_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -871,44 +532,6 @@ mod tests {
             "Should use resolved type: {}",
             arm_str
         );
-    }
-
-    #[test]
-    fn test_decode_output_custom_returns_error() {
-        let type_map = HashMap::new();
-
-        let functions = vec![make_function(
-            "custom_fn",
-            quote! { () },
-            quote! { Vec<u8> },
-            true,
-        )];
-        let arms = generate_decode_output_arms(&functions, &type_map, &[]);
-
-        assert_eq!(arms.len(), 1);
-        let arm_str = normalize_tokens(arms[0].clone());
-        assert!(arm_str.contains("Err"));
-        assert!(arm_str.contains("custom handler required"));
-    }
-
-    #[test]
-    fn test_decode_output_with_custom_handler() {
-        let type_map = HashMap::new();
-        let functions = vec![];
-
-        let custom_handlers = vec![make_custom_handler(
-            "extra_data",
-            DataDriverRole::DecodeOutput,
-            "decode_extra_output",
-        )];
-
-        let arms = generate_decode_output_arms(&functions, &type_map, &custom_handlers);
-
-        assert_eq!(arms.len(), 1);
-        let arm_str = normalize_tokens(arms[0].clone());
-        assert!(arm_str.contains("\"extra_data\""));
-        assert!(arm_str.contains("decode_extra_output"));
-        assert!(arm_str.contains("(rkyv)"));
     }
 
     // =========================================================================
@@ -928,7 +551,6 @@ mod tests {
             params: vec![],
             input_type: input,
             output_type: output,
-            is_custom: false,
             returns_ref: false,
             receiver: Receiver::Ref,
             trait_name: None,
@@ -951,7 +573,7 @@ mod tests {
             quote! { () },
             quote! { (ItemId, PendingItem) },
         )];
-        let arms = generate_decode_output_arms(&functions, &type_map, &[]);
+        let arms = generate_decode_output_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -986,7 +608,7 @@ mod tests {
             quote! { () },
             quote! { ItemId },
         )];
-        let arms = generate_decode_output_arms(&functions, &type_map, &[]);
+        let arms = generate_decode_output_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -1003,13 +625,8 @@ mod tests {
         let type_map = HashMap::new();
 
         // Function without feed_type should use output_type as before
-        let functions = vec![make_function(
-            "is_paused",
-            quote! { () },
-            quote! { bool },
-            false,
-        )];
-        let arms = generate_decode_output_arms(&functions, &type_map, &[]);
+        let functions = vec![make_function("is_paused", quote! { () }, quote! { bool })];
+        let arms = generate_decode_output_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -1027,7 +644,7 @@ mod tests {
             quote! { () },
             quote! { u64 },
         )];
-        let arms = generate_decode_output_arms(&functions, &type_map, &[]);
+        let arms = generate_decode_output_arms(&functions, &type_map);
 
         assert_eq!(arms.len(), 1);
         let arm_str = normalize_tokens(arms[0].clone());
@@ -1190,13 +807,13 @@ mod tests {
         type_map.insert("Address".to_string(), "my_crate::Address".to_string());
 
         let functions = vec![
-            make_function("init", quote! { Address }, quote! { () }, false),
-            make_function("is_paused", quote! { () }, quote! { bool }, false),
+            make_function("init", quote! { Address }, quote! { () }),
+            make_function("is_paused", quote! { () }, quote! { bool }),
         ];
 
         let events = vec![make_event("PAUSED", quote! { PauseEvent })];
 
-        let output = module(&type_map, &functions, &events, &[]);
+        let output = module(&type_map, &functions, &events);
         let output_str = normalize_tokens(output);
 
         // Verify module structure

--- a/contract-macro/src/extract.rs
+++ b/contract-macro/src/extract.rs
@@ -14,10 +14,9 @@ use syn::{
 };
 
 use crate::{
-    ContractData, CustomDataDriverHandler, DataDriverRole, EmitVisitor, EventInfo, FunctionInfo,
-    ImportInfo, ParameterInfo, TraitImplInfo, event_suppressed, extract_doc_comment,
-    extract_feeds_attribute, extract_receiver, get_feed_exprs, has_custom_attribute,
-    has_empty_body, parse, validate, validate_feed_type_match,
+    ContractData, EmitVisitor, EventInfo, FunctionInfo, ImportInfo, ParameterInfo, TraitImplInfo,
+    event_suppressed, extract_doc_comment, extract_feeds_attribute, extract_receiver,
+    get_feed_exprs, has_empty_body, parse, validate, validate_feed_type_match,
 };
 
 /// Validate feed-related attributes for a method.
@@ -171,7 +170,6 @@ pub(crate) fn trait_methods(trait_impl: &TraitImplInfo) -> Result<Vec<FunctionIn
 
             let name = method.sig.ident.clone();
             let doc = extract_doc_comment(&method.attrs);
-            let is_custom = has_custom_attribute(&method.attrs);
             let feed_type = extract_feeds_attribute(&method.attrs);
             let receiver = extract_receiver(method);
 
@@ -220,7 +218,6 @@ pub(crate) fn trait_methods(trait_impl: &TraitImplInfo) -> Result<Vec<FunctionIn
                 params,
                 input_type,
                 output_type,
-                is_custom,
                 returns_ref,
                 receiver,
                 trait_name,
@@ -270,7 +267,6 @@ pub(crate) fn public_methods(impl_block: &ItemImpl) -> Result<Vec<FunctionInfo>,
 
             let name = method.sig.ident.clone();
             let doc = extract_doc_comment(&method.attrs);
-            let is_custom = has_custom_attribute(&method.attrs);
             let feed_type = extract_feeds_attribute(&method.attrs);
             let receiver = extract_receiver(method);
             let has_emit_call = method_has_emit_call(method);
@@ -298,7 +294,6 @@ pub(crate) fn public_methods(impl_block: &ItemImpl) -> Result<Vec<FunctionInfo>,
                 params,
                 input_type,
                 output_type,
-                is_custom,
                 returns_ref,
                 receiver,
                 trait_name: None, // Not a trait method
@@ -814,110 +809,6 @@ fn trait_impls<'a>(items: &'a [Item], contract_name: &str) -> Vec<TraitImplInfo<
         .collect()
 }
 
-/// Extract custom data-driver handler functions from module items.
-///
-/// Looks for functions with attributes like:
-/// - `#[contract(encode_input = "fn_name")]`
-/// - `#[contract(decode_input = "fn_name")]`
-/// - `#[contract(decode_output = "fn_name")]`
-fn custom_data_driver_handlers(items: &[Item]) -> Vec<CustomDataDriverHandler> {
-    let mut handlers = Vec::new();
-
-    for item in items {
-        let Item::Fn(func) = item else {
-            continue;
-        };
-
-        for attr in &func.attrs {
-            if !attr.path().is_ident("contract") {
-                continue;
-            }
-
-            let Ok(meta) = attr.meta.require_list() else {
-                continue;
-            };
-
-            // Parse: encode_input = "fn_name", decode_input = "fn_name", or decode_output =
-            // "fn_name"
-            let tokens = meta.tokens.clone();
-            let mut iter = tokens.into_iter().peekable();
-
-            // Look for role identifier (encode_input, decode_input, decode_output)
-            let Some(proc_macro2::TokenTree::Ident(role_ident)) = iter.next() else {
-                continue;
-            };
-
-            let role = match role_ident.to_string().as_str() {
-                "encode_input" => DataDriverRole::EncodeInput,
-                "decode_input" => DataDriverRole::DecodeInput,
-                "decode_output" => DataDriverRole::DecodeOutput,
-                _ => continue,
-            };
-
-            // Expect "="
-            let Some(proc_macro2::TokenTree::Punct(punct)) = iter.next() else {
-                continue;
-            };
-            if punct.as_char() != '=' {
-                continue;
-            }
-
-            // Expect string literal with function name
-            let Some(proc_macro2::TokenTree::Literal(lit)) = iter.next() else {
-                continue;
-            };
-            let lit_str = lit.to_string();
-            // Remove quotes from the literal
-            let fn_name = lit_str.trim_matches('"').to_string();
-
-            // Clone the function without the contract attribute
-            let mut func_clone = func.clone();
-            func_clone.attrs.retain(|a| !a.path().is_ident("contract"));
-
-            handlers.push(CustomDataDriverHandler {
-                fn_name,
-                role,
-                func: func_clone,
-            });
-        }
-    }
-
-    handlers
-}
-
-/// Check if an item is a custom data-driver handler function.
-///
-/// Returns true if the item has a `#[contract(encode_input = ...)]`,
-/// `#[contract(decode_input = ...)]`, or `#[contract(decode_output = ...)]`
-/// attribute.
-pub(crate) fn is_custom_handler(item: &Item) -> bool {
-    let Item::Fn(func) = item else {
-        return false;
-    };
-
-    for attr in &func.attrs {
-        if !attr.path().is_ident("contract") {
-            continue;
-        }
-
-        let Ok(meta) = attr.meta.require_list() else {
-            continue;
-        };
-
-        let tokens = meta.tokens.clone();
-        let mut iter = tokens.into_iter();
-
-        if let Some(proc_macro2::TokenTree::Ident(ident)) = iter.next() {
-            let name = ident.to_string();
-            if name == "encode_input" || name == "decode_input" || name == "decode_output" {
-                return true;
-            }
-        }
-    }
-
-    false
-}
-
 /// Extract contract data from the module, validating constraints.
 ///
 /// Returns an error if validation fails.
@@ -945,7 +836,6 @@ pub(crate) fn contract_data<'a>(
     validate::init_method(&name, &impl_blocks)?;
 
     let trait_impls = trait_impls(items, &name);
-    let custom_handlers = custom_data_driver_handlers(items);
 
     Ok(ContractData {
         imports,
@@ -953,7 +843,6 @@ pub(crate) fn contract_data<'a>(
         contract_ident: struct_.ident.clone(),
         impl_blocks,
         trait_impls,
-        custom_handlers,
     })
 }
 

--- a/contract-macro/src/generate.rs
+++ b/contract-macro/src/generate.rs
@@ -54,7 +54,6 @@ pub(crate) fn schema(
                     doc: #doc,
                     input: #input_str,
                     output: #output_str,
-                    custom: false,
                 }
             }
         })

--- a/contract-macro/src/generate.rs
+++ b/contract-macro/src/generate.rs
@@ -43,7 +43,6 @@ pub(crate) fn schema(
             let doc = f.doc.as_deref().unwrap_or("");
             let input = &f.input_type;
             let output = &f.output_type;
-            let custom = f.is_custom;
 
             // Convert type tokens to string for the schema
             let input_str = input.to_string();
@@ -55,7 +54,7 @@ pub(crate) fn schema(
                     doc: #doc,
                     input: #input_str,
                     output: #output_str,
-                    custom: #custom,
+                    custom: false,
                 }
             }
         })
@@ -226,7 +225,7 @@ pub(crate) fn strip_contract_attributes(mut impl_block: ItemImpl) -> ItemImpl {
         .attrs
         .retain(|attr| !attr.path().is_ident("contract"));
 
-    // Strip from methods (e.g., #[contract(custom)])
+    // Strip from methods (e.g., #[contract(no_event)], #[contract(feeds = "...")])
     for item in &mut impl_block.items {
         if let ImplItem::Fn(method) = item {
             method
@@ -272,7 +271,6 @@ mod tests {
             params: vec![],
             input_type: quote! { () },
             output_type: quote! { bool },
-            is_custom: false,
             returns_ref: false,
             receiver: Receiver::Ref,
             trait_name: None,
@@ -310,7 +308,6 @@ mod tests {
             }],
             input_type: quote! { Address },
             output_type: quote! { () },
-            is_custom: false,
             returns_ref: false,
             receiver: Receiver::RefMut,
             trait_name: None,
@@ -356,7 +353,6 @@ mod tests {
             ],
             input_type: quote! { (Address, u64) },
             output_type: quote! { () },
-            is_custom: false,
             returns_ref: false,
             receiver: Receiver::RefMut,
             trait_name: None,
@@ -390,7 +386,6 @@ mod tests {
                 params: vec![],
                 input_type: quote! { () },
                 output_type: quote! { () },
-                is_custom: false,
                 returns_ref: false,
                 receiver: Receiver::RefMut,
                 trait_name: None,
@@ -402,7 +397,6 @@ mod tests {
                 params: vec![],
                 input_type: quote! { () },
                 output_type: quote! { () },
-                is_custom: false,
                 returns_ref: false,
                 receiver: Receiver::RefMut,
                 trait_name: None,
@@ -441,7 +435,6 @@ mod tests {
             params: vec![],
             input_type: quote! { () },
             output_type: quote! { LargeStruct },
-            is_custom: false,
             returns_ref: true,
             receiver: Receiver::Ref,
             trait_name: None,
@@ -479,7 +472,6 @@ mod tests {
             }],
             input_type: quote! { LargeStruct },
             output_type: quote! { () },
-            is_custom: false,
             returns_ref: false,
             receiver: Receiver::RefMut,
             trait_name: None,
@@ -517,7 +509,6 @@ mod tests {
             }],
             input_type: quote! { Data },
             output_type: quote! { () },
-            is_custom: false,
             returns_ref: false,
             receiver: Receiver::RefMut,
             trait_name: None,

--- a/contract-macro/src/lib.rs
+++ b/contract-macro/src/lib.rs
@@ -102,8 +102,6 @@ struct FunctionInfo {
     input_type: TokenStream2,
     /// The output type (dereferenced if the method returns a reference).
     output_type: TokenStream2,
-    /// Whether this method has the `#[contract(custom)]` attribute.
-    is_custom: bool,
     /// Whether the method returns a reference (requires `.clone()` in wrapper).
     returns_ref: bool,
     /// The method's receiver type (`&self`, `&mut self`, or none).
@@ -124,28 +122,6 @@ struct EventInfo {
     topic: String,
     /// The event data type.
     data_type: TokenStream2,
-}
-
-/// Which data-driver method a custom handler implements.
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum DataDriverRole {
-    /// Handles `encode_input_fn` for a data-driver function.
-    EncodeInput,
-    /// Handles `decode_input_fn` for a data-driver function.
-    DecodeInput,
-    /// Handles `decode_output_fn` for a data-driver function.
-    DecodeOutput,
-}
-
-/// Information about a custom data-driver handler function.
-struct CustomDataDriverHandler {
-    /// The data-driver function name this handler is for (e.g.,
-    /// `"extra_data"`).
-    fn_name: String,
-    /// Which role this handler plays.
-    role: DataDriverRole,
-    /// The function item itself (to be moved into `data_driver` module).
-    func: syn::ItemFn,
 }
 
 /// Visitor to find `abi::emit()` calls within function bodies.
@@ -314,8 +290,6 @@ struct ContractData<'a> {
     impl_blocks: Vec<&'a ItemImpl>,
     /// Trait implementations with `#[contract(expose = [...])]` attributes.
     trait_impls: Vec<TraitImplInfo<'a>>,
-    /// Custom data-driver handler functions.
-    custom_handlers: Vec<CustomDataDriverHandler>,
 }
 
 // ============================================================================
@@ -370,20 +344,6 @@ fn extract_doc_comment(attrs: &[Attribute]) -> Option<String> {
     } else {
         Some(docs.join(" "))
     }
-}
-
-/// Check if method has #[contract(custom)] attribute.
-fn has_custom_attribute(attrs: &[Attribute]) -> bool {
-    attrs.iter().any(|attr| {
-        if attr.path().is_ident("contract") {
-            // Parse the attribute arguments
-            if let Ok(meta) = attr.meta.require_list() {
-                let tokens = meta.tokens.to_string();
-                return tokens.contains("custom");
-            }
-        }
-        false
-    })
 }
 
 /// Check if method has `#[contract(no_event)]` attribute to suppress the emit
@@ -515,7 +475,6 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
         contract_ident,
         impl_blocks,
         trait_impls,
-        custom_handlers,
     } = data;
 
     // Extract functions and events from all inherent impl blocks
@@ -563,7 +522,7 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let type_map = resolve::build_type_map(&imports, &functions, &events);
 
     // Generate data_driver module at crate root level (outside contract module)
-    let data_driver = data_driver::module(&type_map, &functions, &events, &custom_handlers);
+    let data_driver = data_driver::module(&type_map, &functions, &events);
 
     // Rebuild the module with stripped contract attributes on methods
     let mod_vis = &module.vis;
@@ -572,8 +531,6 @@ pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let new_items: Vec<_> = items
         .iter()
-        // Filter out custom data-driver handler functions (they go in the data_driver module)
-        .filter(|item| !extract::is_custom_handler(item))
         .map(|item| {
             if let Item::Impl(impl_block) = item
                 && let Type::Path(type_path) = &*impl_block.self_ty
@@ -823,43 +780,5 @@ mod tests {
         let doc = extract_doc_comment(&attrs);
         assert!(doc.is_some());
         assert_eq!(doc.unwrap(), "The doc comment.");
-    }
-
-    // =========================================================================
-    // has_custom_attribute tests
-    // =========================================================================
-
-    #[test]
-    fn test_has_custom_attribute_true() {
-        let attrs: Vec<Attribute> = vec![syn::parse_quote!(#[contract(custom)])];
-        assert!(has_custom_attribute(&attrs));
-    }
-
-    #[test]
-    fn test_has_custom_attribute_false() {
-        let attrs: Vec<Attribute> = vec![syn::parse_quote!(#[doc = "Some doc"])];
-        assert!(!has_custom_attribute(&attrs));
-    }
-
-    #[test]
-    fn test_has_custom_attribute_empty() {
-        let attrs: Vec<Attribute> = vec![];
-        assert!(!has_custom_attribute(&attrs));
-    }
-
-    #[test]
-    fn test_has_custom_attribute_other_contract_attr() {
-        let attrs: Vec<Attribute> = vec![syn::parse_quote!(#[contract(expose = [foo])])];
-        assert!(!has_custom_attribute(&attrs));
-    }
-
-    #[test]
-    fn test_has_custom_attribute_mixed() {
-        let attrs: Vec<Attribute> = vec![
-            syn::parse_quote!(#[doc = "Some doc"]),
-            syn::parse_quote!(#[contract(custom)]),
-            syn::parse_quote!(#[inline]),
-        ];
-        assert!(has_custom_attribute(&attrs));
     }
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -155,7 +155,6 @@ The macro analyzes the contract module and extracts metadata:
 | Parameters after `self` | Input type (tupled if multiple) |
 | Return type | Output type (`()` if none) |
 | `abi::emit(topic, data)` | Event emission |
-| `#[contract(custom)]` | Requires manual encode/decode in data-driver |
 | `#[contract(feeds = "Type")]` | Specifies the type fed via `abi::feed()` for streaming functions |
 | Doc comments | Included in schema |
 
@@ -234,55 +233,6 @@ The macro validates `feeds` usage and produces helpful error messages:
 
 These checks catch common mistakes at compile time rather than runtime.
 
-### Custom Data-Driver Functions
-
-Sometimes you need data-driver functions that don't correspond to actual contract methods—for example, utility functions for custom serialization. These are "virtual" functions that only exist in the data-driver.
-
-Use the `#[contract(encode_input = "fn_name")]`, `#[contract(decode_input = "fn_name")]`, or `#[contract(decode_output = "fn_name")]` attributes on functions to define custom handlers:
-
-```rust
-#[contract]
-mod my_contract {
-    // ... contract impl ...
-
-    /// Custom encoder for the "raw_id" data-driver function.
-    /// This function is NOT a contract method - it only exists in the data-driver.
-    #[contract(encode_input = "raw_id")]
-    fn encode_raw_id(json: &str) -> Result<Vec<u8>, dusk_data_driver::Error> {
-        let id: u64 = serde_json::from_str(json)?;
-        Ok(id.to_le_bytes().to_vec())
-    }
-
-    /// Custom decoder for the "raw_id" data-driver function.
-    #[contract(decode_output = "raw_id")]
-    fn decode_raw_id(bytes: &[u8]) -> Result<dusk_data_driver::JsonValue, dusk_data_driver::Error> {
-        if bytes.len() != 8 {
-            return Err(dusk_data_driver::Error::Unsupported(
-                alloc::format!("expected 8 bytes, got {}", bytes.len())
-            ));
-        }
-        let mut buf = [0u8; 8];
-        buf.copy_from_slice(bytes);
-        let id = u64::from_le_bytes(buf);
-        Ok(serde_json::to_value(id)?)
-    }
-}
-```
-
-**Important:** These handler functions are moved into the generated `data_driver` module during macro expansion, so they must use fully-qualified paths for all types (except those available in the data-driver module like `dusk_data_driver::Error` and `alloc::vec::Vec`).
-
-The macro will:
-1. Remove these functions from the contract module (they're not contract methods)
-2. Move them into the generated `data_driver` module
-3. Generate match arms that call them for the specified function name
-
-Each data-driver function can have up to three handlers:
-- `encode_input`: Called by `encode_input_fn(fn_name, json) -> Vec<u8>`
-- `decode_input`: Called by `decode_input_fn(fn_name, rkyv) -> JsonValue`
-- `decode_output`: Called by `decode_output_fn(fn_name, rkyv) -> JsonValue`
-
-If a handler is not provided for a role, the data-driver will return an "Unsupported" error for that operation.
-
 ## Generated Output
 
 ### 1. Contract Schema
@@ -304,14 +254,12 @@ pub const CONTRACT_SCHEMA: dusk_forge::schema::Contract = dusk_forge::schema::Co
             doc: "Initializes the contract with an owner.",
             input: "PublicKey",
             output: "()",
-            custom: false,
         },
         Function {
             name: "counter",
             doc: "Returns the current counter value.",
             input: "()",
             output: "u64",
-            custom: false,
         },
         // ...
     ],
@@ -508,15 +456,6 @@ pub fn empty_id() -> ItemId
 
 No `STATE` access needed. The wrapper calls `MyContract::empty_id()` directly.
 
-### Custom Serialization
-
-```rust
-#[contract(custom)]
-pub fn raw_bytes(&self, data: Vec<u8>) -> Vec<u8>
-```
-
-Marked in schema with `custom: true`. The data-driver returns an "unsupported" error for these functions — custom handlers must be provided via `#[contract(encode_input = "...")]` / `#[contract(decode_output = "...")]` if data-driver support is needed.
-
 ## Comparison
 
 | Aspect | Without Macro | With Macro |
@@ -541,4 +480,3 @@ The `#[contract]` macro provides:
 
 Manual work remaining:
 - Type definitions (shared in `types/`)
-- Custom serialization handlers (rare, via `#[contract(custom)]`)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -24,8 +24,6 @@ pub struct Function {
     pub input: &'static str,
     /// Output type name (or "()" for no output).
     pub output: &'static str,
-    /// Whether this function requires custom serialization.
-    pub custom: bool,
 }
 
 /// Schema for a contract event.

--- a/tests/test-contract/Cargo.toml
+++ b/tests/test-contract/Cargo.toml
@@ -8,9 +8,6 @@ dusk-core = { workspace = true }
 dusk-data-driver = { version = "0.3", optional = true }
 dusk-forge = { path = "../.." }
 types = { path = "../types" }
-serde_json = { workspace = true, default-features = false, features = [
-  "alloc",
-], optional = true }
 
 [dev-dependencies]
 dusk-core = { workspace = true }
@@ -32,7 +29,6 @@ data-driver = [
   "dusk-data-driver/wasm-export",
   "types/serde",
   "dusk-core/serde",
-  "dep:serde_json",
 ]
 # Data-driver with alloc exports for JavaScript environments
 data-driver-js = ["data-driver", "dusk-data-driver/alloc"]

--- a/tests/test-contract/src/lib.rs
+++ b/tests/test-contract/src/lib.rs
@@ -12,7 +12,6 @@
 //! - Event emission, streaming via `abi::feed`
 //! - Trait exposure with default implementations
 //! - Multiple impl blocks, associated functions
-//! - Custom data-driver encode/decode
 
 #![no_std]
 #![cfg(target_family = "wasm")]
@@ -273,34 +272,5 @@ mod test_contract {
         /// Empty body signals the macro to use the trait's default
         /// implementation.
         fn version() -> String {}
-    }
-
-    // =========================================================================
-    // Custom data-driver functions
-    // =========================================================================
-
-    /// Custom encoder for the `raw_id` data-driver function.
-    ///
-    /// Demonstrates custom data-driver functions that exist only in the
-    /// data-driver WASM, not as contract methods.
-    #[contract(encode_input = "raw_id")]
-    fn encode_raw_id(json: &str) -> Result<alloc::vec::Vec<u8>, dusk_data_driver::Error> {
-        let id: u64 = serde_json::from_str(json)?;
-        Ok(id.to_le_bytes().to_vec())
-    }
-
-    /// Custom decoder for the `raw_id` data-driver function.
-    #[contract(decode_output = "raw_id")]
-    fn decode_raw_id(bytes: &[u8]) -> Result<dusk_data_driver::JsonValue, dusk_data_driver::Error> {
-        if bytes.len() != 8 {
-            return Err(dusk_data_driver::Error::Unsupported(alloc::format!(
-                "expected 8 bytes, got {}",
-                bytes.len()
-            )));
-        }
-        let mut buf = [0u8; 8];
-        buf.copy_from_slice(bytes);
-        let id = u64::from_le_bytes(buf);
-        Ok(serde_json::to_value(id)?)
     }
 }

--- a/tests/test-contract/tests/schema.rs
+++ b/tests/test-contract/tests/schema.rs
@@ -440,49 +440,6 @@ impl DataDriverWasm {
     }
 }
 
-#[test]
-fn test_custom_data_driver_function_encode() {
-    let mut driver = DataDriverWasm::new();
-
-    // Test encoding a u64 via the custom "raw_id" function
-    let input_json = "42";
-    let encoded = driver
-        .encode_input("raw_id", input_json)
-        .expect("Failed to encode raw_id");
-
-    assert_eq!(encoded.len(), 8, "Expected 8 bytes for u64");
-    assert_eq!(encoded, 42u64.to_le_bytes().to_vec());
-}
-
-#[test]
-fn test_custom_data_driver_function_decode() {
-    let mut driver = DataDriverWasm::new();
-
-    // Test decoding raw bytes back to u64 via the custom "raw_id" function
-    let rkyv_data = 42u64.to_le_bytes().to_vec();
-    let decoded = driver
-        .decode_output("raw_id", &rkyv_data)
-        .expect("Failed to decode raw_id");
-
-    assert_eq!(decoded, serde_json::json!(42));
-}
-
-#[test]
-fn test_custom_data_driver_function_roundtrip() {
-    let mut driver = DataDriverWasm::new();
-
-    let original_json = "12345";
-    let encoded = driver
-        .encode_input("raw_id", original_json)
-        .expect("Failed to encode raw_id");
-
-    let decoded = driver
-        .decode_output("raw_id", &encoded)
-        .expect("Failed to decode raw_id");
-
-    assert_eq!(decoded, serde_json::json!(12345));
-}
-
 // =============================================================================
 // Tests for #[contract(feeds = "Type")] attribute
 // =============================================================================

--- a/tests/test-contract/tests/schema.rs
+++ b/tests/test-contract/tests/schema.rs
@@ -953,33 +953,6 @@ fn test_schema_import_paths() {
 }
 
 #[test]
-fn test_schema_custom_flag() {
-    let schema_json = get_schema_from_wasm();
-    let schema: serde_json::Value =
-        serde_json::from_str(&schema_json).expect("Failed to parse schema JSON");
-
-    let functions = schema["functions"]
-        .as_array()
-        .expect("functions should be an array");
-
-    // Regular functions should have custom = false
-    let counter = functions
-        .iter()
-        .find(|f| f["name"] == "counter")
-        .expect("counter should exist");
-    assert_eq!(counter["custom"], false, "counter should not be custom");
-
-    let set_counter = functions
-        .iter()
-        .find(|f| f["name"] == "set_counter")
-        .expect("set_counter should exist");
-    assert_eq!(
-        set_counter["custom"], false,
-        "set_counter should not be custom"
-    );
-}
-
-#[test]
 fn test_schema_nested_generic_types() {
     let schema_json = get_schema_from_wasm();
     let schema: serde_json::Value =
@@ -1198,10 +1171,6 @@ fn test_schema_function_fields_consistent() {
         assert!(
             func_obj.contains_key("output"),
             "Function at index {i} missing 'output' field"
-        );
-        assert!(
-            func_obj.contains_key("custom"),
-            "Function at index {i} missing 'custom' field"
         );
     }
 }


### PR DESCRIPTION
## Summary

Deletes the `#[contract(custom)]` / `#[contract(encode_input = ...)]` / `decode_input` / `decode_output` escape hatch that existed to support the original EVM bridge. The new duskevm bridge — the only production consumer of this macro — uses zero custom handlers across all its contracts; everything flows through the default `rkyv` / JSON codegen.

The feature was the source of recurring macro bugs because user code gets moved out of its original module and loses its resolution context — a tension with Rust's module/import model itself that no incremental fix resolves cleanly. YAGNI applies.

Removes from `contract-macro/`:
- `CustomDataDriverHandler` / `DataDriverRole` types
- `extract::custom_data_driver_handlers` / `extract::is_custom_handler` / `has_custom_attribute`
- Custom-handler match arms in encode/decode generators
- The `is_custom` field on `FunctionInfo`
- All custom-handler attribute parsing in `extract.rs` and `lib.rs`

Removes from `test-contract/`:
- The `encode_raw_id` / `decode_raw_id` fixture and its three schema-test cases
- The optional `serde_json` dependency that only those handlers needed

Also drops the now-dead `Function::custom` field from `dusk_forge::schema` (breaking change to the public schema API — it was hardcoded to `false` in every generated schema after the macro change), strips the README and design-doc sections that taught the deleted feature.

Supersedes #19.