### PR TITLE
workspace: Update Dusk dependencies to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Pin Dusk workspace, template, and test-contract dependencies to the explicit `1.6.0` release constraint.
 - Replace the four hand-rolled `#[contract(...)]` directive parsers with a single typed pass returning a `ContractDirectives` struct. Malformed inputs (typo'd keyword, wrong shape, unparseable feeds type, `expose = (...)` with parens, extra tokens after a `(topic, EventType)` tuple) now produce a `compile_error!` instead of being silently dropped. Duplicate directives (within one attribute or across multiple `#[contract(...)]` attributes on the same item) also error [#24].
 - Move workspace to Rust edition 2024 on the stable toolchain (MSRV 1.85). Generated contract wrappers now use `#[unsafe(no_mangle)]`.
 - Remove `-Z build-std=core,alloc` from contract builds (no longer needed on stable).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rust-version = "1.85"
 # Workspace internal dependencies
 dusk-forge-contract = { version = "0.1.1", path = "./contract-macro/" }
 
-dusk-core = { version = "1.6", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0" }
+dusk-core = { version = "1.6.0", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0" }
 bytecheck = { version = "0.6.12", default-features = false }
 rkyv = { version = "0.7", default-features = false, features = [
   "alloc",
@@ -59,7 +59,7 @@ wasmtime = "25"
 blake3 = "1"
 
 # Pin to match L1Contracts versions
-dusk-vm = { version = "1.6", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0", default-features = false }
+dusk-vm = { version = "1.6.0", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0", default-features = false }
 
 # Enable overflow checks in release builds for contract safety
 [profile.release]

--- a/contract-template/Cargo.toml
+++ b/contract-template/Cargo.toml
@@ -45,7 +45,7 @@ rust-version = "1.85"
 # WASM Dependencies (contract is gated by #![cfg(target_family = "wasm")])
 # -----------------------------------------------------------------------------
 [target.'cfg(target_family = "wasm")'.dependencies]
-dusk-core = { version = "1.6", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0" }
+dusk-core = { version = "1.6.0", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0" }
 dusk-data-driver = { version = "0.3", optional = true }
 dusk-forge = "0.2.2"
 
@@ -53,8 +53,8 @@ dusk-forge = "0.2.2"
 # Dev Dependencies (for tests running on the host, not in WASM)
 # -----------------------------------------------------------------------------
 [dev-dependencies]
-dusk-core = { version = "1.6", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0" }
-dusk-vm = { version = "1.6", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0", default-features = false }
+dusk-core = { version = "1.6.0", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0" }
+dusk-vm = { version = "1.6.0", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0", default-features = false }
 tempfile = "3"
 
 # -----------------------------------------------------------------------------

--- a/tests/test-contract/Cargo.toml
+++ b/tests/test-contract/Cargo.toml
@@ -16,7 +16,7 @@ types = { path = "../types" }
 ff = { version = "0.13", default-features = false }
 rand = "0.8"
 rkyv = { workspace = true, features = ["validation"] }
-rusk-prover = { version = "1.6", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0" }
+rusk-prover = { version = "1.6.0", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0" }
 serde_json = { workspace = true, default-features = true }
 wasmtime = "25"
 


### PR DESCRIPTION
## Summary

Updates Forge's Dusk dependencies to use the explicit `1.6.0` release constraint, matching the existing `dusk-core-1.6.0` git tag.

Updated:
- `dusk-core`
- `dusk-vm`
- `rusk-prover`
- contract template dependency declarations

Also adds a changelog entry under `Unreleased`.

Note: `main` was already using the `dusk-core-1.6.0` git tag; this PR makes the manifest version constraints explicit as `1.6.0`.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --all-targets`
- [x] `make test`
- [x] `make clippy`
- [x] `git diff --check`