### PR TITLE
Release macro to v0.2.0 and forge to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-26
+
 ### Added
 
 - Add compile-fail and compile-pass test harness for the contract macro.
@@ -90,7 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#27]: https://github.com/dusk-network/forge/issues/27
 
 <!-- Releases -->
-[Unreleased]: https://github.com/dusk-network/forge/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/dusk-network/forge/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/dusk-network/forge/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/dusk-network/forge/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/dusk-network/forge/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/dusk-network/forge/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-forge"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A smart contract development framework for Dusk"
@@ -30,7 +30,7 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 # Workspace internal dependencies
-dusk-forge-contract = { version = "0.1.1", path = "./contract-macro/" }
+dusk-forge-contract = { version = "0.2.0", path = "./contract-macro/" }
 
 dusk-core = { version = "1.6", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0" }
 bytecheck = { version = "0.6.12", default-features = false }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dusk Forge
 <img src="assets/dusk-forge-illustration.png"  alt="Dusk Forge Illustration"></img>
 <p align="center">
 
-<a href="https://github.com/HDauven/dusk-forge" target="_blank">
+<a href="https://github.com/dusk-network/forge" target="_blank">
   <img src="https://img.shields.io/badge/github-dusk%20forge-blueviolet?logo=github" alt="Repository">
 </a>
 <a href="https://docs.rs/dusk-forge/" target="_blank">

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ All runtime dependencies go in the WASM-only section because contracts are gated
 [target.'cfg(target_family = "wasm")'.dependencies]
 dusk-core = "1.4"
 dusk-data-driver = { version = "0.3", optional = true }  # Only for data-driver
-dusk-forge = "0.1"
+dusk-forge = "0.3"
 
 [dev-dependencies]
 dusk-core = "1.4"   # Same types, but for host-side tests

--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ dusk-data-driver = { version = "0.3", optional = true }  # Only for data-driver
 dusk-forge = "0.3"
 
 [dev-dependencies]
-dusk-core = "1.4"   # Same types, but for host-side tests
-dusk-vm = "0.1"     # To run contract in tests
+dusk-core = "1.6"   # Same types, but for host-side tests
+dusk-vm = "1.6"     # To run contract in tests
 ```
 
 ### Features

--- a/contract-macro/Cargo.toml
+++ b/contract-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-forge-contract"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 description = "A smart contract development macro for Dusk"
 license = "MPL-2.0"

--- a/contract-template/Cargo.toml
+++ b/contract-template/Cargo.toml
@@ -47,7 +47,7 @@ rust-version = "1.85"
 [target.'cfg(target_family = "wasm")'.dependencies]
 dusk-core = { version = "1.6", git = "https://github.com/dusk-network/rusk", tag = "dusk-core-1.6.0" }
 dusk-data-driver = { version = "0.3", optional = true }
-dusk-forge = "0.2.2"
+dusk-forge = "0.3.0"
 
 # -----------------------------------------------------------------------------
 # Dev Dependencies (for tests running on the host, not in WASM)


### PR DESCRIPTION
## [0.3.0] - 2026-05-26

### Added

- Add compile-fail and compile-pass test harness for the contract macro.
- Add the `ContractEvent` trait and the `#[contract(events = [Type, ...])]` module attribute to declare a contract's events once at module scope. A type may carry multiple topics via `TOPICS`.
- Add compile-time validation that in-module `abi::emit()` calls reference a registered event type.
- Add the `dusk-forge` CLI with `new`, `build`, `test`, and `check` commands for contract project scaffolding and workflows.
- Add `expand`, `clean`, and `completions` commands to the `dusk-forge` CLI.
- Add `schema`, `call`, and `verify` commands to the `dusk-forge` CLI.

### Changed

- Rename `schema::Event.topic` to `topics` (a slice), populated from `ContractEvent::TOPICS`; `Contract::get_event` matches against the slice.
- Replace the hand-rolled `#[contract(...)]` directive parsers with a single typed pass returning a `ContractDirectives` struct. Malformed inputs (typo'd keyword, wrong shape, unparseable feeds type, `expose = (...)` with parens) now produce a `compile_error!` instead of being silently dropped. Duplicate directives (within one attribute or across multiple `#[contract(...)]` attributes on the same item) also error [#24].
- Restructure the contract-macro parse phase (internal — no public API or generated-code changes) [#27].
- Move workspace to Rust edition 2024 on the stable toolchain (MSRV 1.85). Generated contract wrappers now use `#[unsafe(no_mangle)]`.
- Remove `-Z build-std=core,alloc` from contract builds (no longer needed on stable).
- Replace EVM-flavored test-bridge with a general-purpose test contract that exercises every `#[contract]` macro code path without domain-specific types.
- Make local forge path overrides opt-in for release builds and harden CLI template/path handling across platforms.

### Fixed

- Make `dusk-forge build data-driver` select the supported project feature (`data-driver-js` or `data-driver`) instead of hardcoding the JS variant.

### Removed

- Remove the per-method `#[contract(emits = [...])]` / `#[contract(no_event)]` directives and the lint requiring every `pub &mut self` method to emit; events are now declared via `#[contract(events = [...])]`.
- Drop the custom data-driver handler escape hatch (`#[contract(custom)]` and the `encode_input` / `decode_input` / `decode_output` attributes). The feature had no production consumers and was the source of recurring macro bugs caused by user code being moved out of its original module and losing its resolution context. Default `rkyv` / JSON codegen is now the only path.

[0.3.0]: https://github.com/dusk-network/forge/compare/v0.2.2...v0.3.0