### PR TITLE
fix(macro): module-local consts visible under data-driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep module-local `const` items visible under the `data-driver` feature so
+  const-generic parameters in public method signatures resolve during
+  data-driver codegen ([#36](https://github.com/dusk-network/forge/issues/36)).
+
 ## [0.3.0] - 2026-05-26
 
 ### Added

--- a/contract-macro/src/generate.rs
+++ b/contract-macro/src/generate.rs
@@ -30,7 +30,16 @@ pub(crate) fn contract_module(
         events,
     } = analysis;
 
-    let type_map = resolve::build_type_map(imports, functions, events);
+    let mod_vis = &module.vis;
+    let mod_name = &module.ident;
+    let mod_attrs = &module.attrs;
+
+    // Module-local items are not `use` imports; feed them into the type map
+    // (as `super::mod::NAME`, with `{ }` on consts) without adding schema entries.
+    let mut all_imports = imports.clone();
+    all_imports.extend(local_const_imports(items, mod_name));
+
+    let type_map = resolve::build_type_map(&all_imports, functions, events);
 
     let schema = schema(contract_name, imports, functions, events, &type_map);
     let state_static = state_static(contract_ident);
@@ -39,10 +48,7 @@ pub(crate) fn contract_module(
     let data_driver = data_driver::module(&type_map, functions, events);
 
     let stripped_items = stripped_module_items(items, contract_name);
-
-    let mod_vis = &module.vis;
-    let mod_name = &module.ident;
-    let mod_attrs = &module.attrs;
+    let data_visible_items = data_visible_items(items);
 
     quote! {
         #[cfg(not(any(feature = "contract", feature = "data-driver")))]
@@ -64,8 +70,160 @@ pub(crate) fn contract_module(
             #externs
         }
 
+        // Plain data (const/struct/enum/type + needed uses) for data-driver sibling codegen.
+        #[cfg(feature = "data-driver")]
+        #(#mod_attrs)*
+        #mod_vis mod #mod_name {
+            #(#data_visible_items)*
+        }
+
         #data_driver
     }
+}
+
+/// Module-local plain data as implicit imports for [`resolve::build_type_map`].
+/// Const paths are brace-wrapped so they splice correctly into const-generic positions.
+fn local_const_imports(items: &[Item], mod_name: &Ident) -> Vec<ImportInfo> {
+    items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Const(item_const) => Some(ImportInfo {
+                name: item_const.ident.to_string(),
+                path: format!("{{ super::{mod_name}::{} }}", item_const.ident),
+            }),
+            Item::Struct(item_struct) => Some(ImportInfo {
+                name: item_struct.ident.to_string(),
+                path: format!("super::{mod_name}::{}", item_struct.ident),
+            }),
+            Item::Enum(item_enum) => Some(ImportInfo {
+                name: item_enum.ident.to_string(),
+                path: format!("super::{mod_name}::{}", item_enum.ident),
+            }),
+            Item::Type(item_type) => Some(ImportInfo {
+                name: item_type.ident.to_string(),
+                path: format!("super::{mod_name}::{}", item_type.ident),
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Plain-data module items safe under `data-driver` (no impl blocks / ABI-only uses).
+fn data_visible_items(items: &[Item]) -> Vec<Item> {
+    let plain: Vec<Item> = items
+        .iter()
+        .filter(|item| {
+            matches!(
+                item,
+                Item::Const(_) | Item::Static(_) | Item::Struct(_) | Item::Enum(_) | Item::Type(_)
+            )
+        })
+        .map(data_visible_item)
+        .collect();
+
+    let referenced: std::collections::HashSet<String> = plain
+        .iter()
+        .flat_map(item_type_words)
+        .collect();
+
+    let used_imports = items.iter().filter(|item| {
+        let Item::Use(item_use) = item else {
+            return false;
+        };
+        use_leaf_names(item_use)
+            .iter()
+            .any(|name| referenced.contains(name))
+    });
+
+    plain.into_iter().chain(used_imports.cloned()).collect()
+}
+
+/// Clone a plain-data item; `const`/`static` become `pub(crate)` so sibling `data_driver` can name them.
+fn data_visible_item(item: &Item) -> Item {
+    match item {
+        Item::Const(item_const) => {
+            let mut item_const = item_const.clone();
+            item_const.vis = syn::parse_quote!(pub(crate));
+            Item::Const(item_const)
+        }
+        Item::Static(item_static) => {
+            let mut item_static = item_static.clone();
+            item_static.vis = syn::parse_quote!(pub(crate));
+            Item::Static(item_static)
+        }
+        Item::Type(item_type) => {
+            let mut item_type = item_type.clone();
+            item_type.vis = syn::parse_quote!(pub(crate));
+            Item::Type(item_type)
+        }
+        _ => item.clone(),
+    }
+}
+
+/// Type/expression identifier words in a plain-data item (not field/item names).
+fn item_type_words(item: &Item) -> Vec<String> {
+    let mut words = Vec::new();
+    match item {
+        Item::Struct(s) => {
+            for field in &s.fields {
+                let ty = &field.ty;
+                words.extend(token_words(&quote! { #ty }.to_string()));
+            }
+        }
+        Item::Enum(e) => {
+            for variant in &e.variants {
+                for field in &variant.fields {
+                    let ty = &field.ty;
+                    words.extend(token_words(&quote! { #ty }.to_string()));
+                }
+                if let Some((_, discriminant)) = &variant.discriminant {
+                    words.extend(token_words(&quote! { #discriminant }.to_string()));
+                }
+            }
+        }
+        Item::Const(c) => {
+            let (ty, expr) = (&c.ty, &c.expr);
+            words.extend(token_words(&quote! { #ty }.to_string()));
+            words.extend(token_words(&quote! { #expr }.to_string()));
+        }
+        Item::Static(s) => {
+            let (ty, expr) = (&s.ty, &s.expr);
+            words.extend(token_words(&quote! { #ty }.to_string()));
+            words.extend(token_words(&quote! { #expr }.to_string()));
+        }
+        Item::Type(t) => {
+            let ty = &t.ty;
+            words.extend(token_words(&quote! { #ty }.to_string()));
+        }
+        _ => {}
+    }
+    words
+}
+
+fn token_words(s: &str) -> std::collections::HashSet<String> {
+    s.split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|w| !w.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn use_leaf_names(item_use: &syn::ItemUse) -> Vec<String> {
+    fn walk(tree: &syn::UseTree, out: &mut Vec<String>) {
+        match tree {
+            syn::UseTree::Path(p) => walk(&p.tree, out),
+            syn::UseTree::Name(n) => out.push(n.ident.to_string()),
+            syn::UseTree::Rename(r) => out.push(r.rename.to_string()),
+            syn::UseTree::Glob(_) => {}
+            syn::UseTree::Group(g) => {
+                for i in &g.items {
+                    walk(i, out);
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(&item_use.tree, &mut out);
+    out
 }
 
 /// Clone the module items, replacing every inherent or trait impl block for
@@ -342,6 +500,7 @@ pub(crate) fn strip_contract_attributes(mut impl_block: ItemImpl) -> ItemImpl {
 mod tests {
     use super::*;
     use crate::parse::{ParameterInfo, Receiver};
+    use quote::ToTokens;
 
     fn normalize_tokens(tokens: &TokenStream2) -> String {
         tokens
@@ -633,5 +792,56 @@ mod tests {
         });
 
         assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn test_local_const_imports_brace_wraps_const() {
+        let module: ItemMod = syn::parse_quote! {
+            mod my_contract {
+                const DEPTH: usize = 16;
+                pub struct MyContract;
+            }
+        };
+        let items = &module.content.as_ref().unwrap().1;
+        let mod_name = format_ident!("my_contract");
+        let imports = local_const_imports(items, &mod_name);
+
+        assert_eq!(imports.len(), 2);
+        assert_eq!(imports[0].name, "DEPTH");
+        assert_eq!(imports[0].path, "{ super::my_contract::DEPTH }");
+        assert_eq!(imports[1].name, "MyContract");
+        assert_eq!(imports[1].path, "super::my_contract::MyContract");
+    }
+
+    #[test]
+    fn test_data_visible_items_skips_impl_only_use() {
+        let module: ItemMod = syn::parse_quote! {
+            mod my_contract {
+                mod only_impl {
+                    pub fn helper() -> u32 {
+                        1
+                    }
+                }
+                use only_impl::helper;
+                const DEPTH: usize = 8;
+                pub struct MyContract;
+                impl MyContract {
+                    pub fn touch(&mut self) {
+                        let _ = helper();
+                    }
+                }
+            }
+        };
+        let items = &module.content.as_ref().unwrap().1;
+
+        let visible = data_visible_items(items);
+        let has_helper_use = visible.iter().any(|item| {
+            matches!(item, Item::Use(u) if u.to_token_stream().to_string().contains("helper"))
+        });
+        assert!(!has_helper_use, "impl-only use must not appear in data-visible items");
+        assert!(
+            visible.iter().any(|i| matches!(i, Item::Const(_))),
+            "const DEPTH should remain visible"
+        );
     }
 }

--- a/contract-macro/src/resolve.rs
+++ b/contract-macro/src/resolve.rs
@@ -75,8 +75,26 @@ fn resolve_syn_type(ty: &syn::Type, import_map: &HashMap<String, String>) -> Str
                 format!("&{resolved}")
             }
         }
+        syn::Type::Array(array) => {
+            let elem = resolve_syn_type(&array.elem, import_map);
+            let len = resolve_const_expr(&array.len, import_map);
+            format!("[{elem}; {len}]")
+        }
         _ => quote::quote!(#ty).to_string(),
     }
+}
+
+/// Resolve a const expression used in array lengths or const-generic parameters.
+fn resolve_const_expr(expr: &syn::Expr, import_map: &HashMap<String, String>) -> String {
+    if let syn::Expr::Path(expr_path) = expr
+        && let Some(ident) = expr_path.path.get_ident()
+    {
+        let name = ident.to_string();
+        if let Some(resolved) = import_map.get(&name) {
+            return resolved.clone();
+        }
+    }
+    quote::quote!(#expr).to_string()
 }
 
 /// Resolve a `TypePath` to its fully qualified string form.
@@ -134,6 +152,7 @@ fn format_generic_args(args: &syn::PathArguments, import_map: &HashMap<String, S
                 .iter()
                 .map(|arg| match arg {
                     syn::GenericArgument::Type(ty) => resolve_syn_type(ty, import_map),
+                    syn::GenericArgument::Const(expr) => resolve_const_expr(expr, import_map),
                     other => quote::quote!(#other).to_string(),
                 })
                 .collect();
@@ -303,6 +322,30 @@ mod tests {
         let ty = quote! { u64 };
         let resolved = resolve_type(&ty, &import_map);
         assert_eq!(resolved, "u64");
+    }
+
+    #[test]
+    fn test_resolve_array_length_const_import() {
+        let import_map = HashMap::from([(
+            "DEPTH".to_string(),
+            "{ super::my_contract::DEPTH }".to_string(),
+        )]);
+
+        let ty = quote! { [u8; DEPTH] };
+        let resolved = resolve_type(&ty, &import_map);
+        assert_eq!(resolved, "[u8; { super::my_contract::DEPTH }]");
+    }
+
+    #[test]
+    fn test_resolve_const_generic_argument() {
+        let import_map = HashMap::from([(
+            "DEPTH".to_string(),
+            "{ super::my_contract::DEPTH }".to_string(),
+        )]);
+
+        let ty = quote! { Opening<DEPTH> };
+        let resolved = resolve_type(&ty, &import_map);
+        assert_eq!(resolved, "Opening<{ super::my_contract::DEPTH }>");
     }
 
     // =========================================================================

--- a/contract-macro/tests/README.md
+++ b/contract-macro/tests/README.md
@@ -23,6 +23,7 @@ Both `compile-fail/` and `compile-pass/src/` are nested by topic, not flat:
 | `events/` | Event registration: the `#[contract(events = [...])]` attribute and `parse::events::validate_emitted_types` |
 | `directives/` | `#[contract(...)]` directive parsing |
 | `feature_gates/` | `contract` / `data-driver` cargo feature enforcement |
+| `data_driver/` | `data-driver` codegen: `generate::contract_module` plain-data visibility, `generate::data_visible_items`, `resolve::resolve_const_expr` |
 
 Add a new topic dir only when a rule has no reasonable home in the existing ones. Topics are stable categories — they should outlive individual rule renames inside `validate.rs`.
 

--- a/contract-macro/tests/compile-fail/feature_gates/missing_feature_gate.stderr
+++ b/contract-macro/tests/compile-fail/feature_gates/missing_feature_gate.stderr
@@ -15,7 +15,6 @@ warning: unexpected `cfg` condition value: `contract`
   = note: no expected values for `feature`
   = note: using a cfg inside a attribute macro will use the cfgs from the destination crate and not the ones from the defining crate
   = help: try referring to `contract` crate for guidance on how handle this unexpected cfg
-  = help: the attribute macro `contract` may come from an old version of the `dusk_forge_contract` crate, try updating your dependency with `cargo update -p dusk_forge_contract`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default
   = note: this warning originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -29,6 +28,5 @@ warning: unexpected `cfg` condition value: `data-driver`
   = note: no expected values for `feature`
   = note: using a cfg inside a attribute macro will use the cfgs from the destination crate and not the ones from the defining crate
   = help: try referring to `contract` crate for guidance on how handle this unexpected cfg
-  = help: the attribute macro `contract` may come from an old version of the `dusk_forge_contract` crate, try updating your dependency with `cargo update -p dusk_forge_contract`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: this warning originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/contract-macro/tests/compile-pass/Cargo.toml
+++ b/contract-macro/tests/compile-pass/Cargo.toml
@@ -9,7 +9,8 @@ publish = false
 [features]
 default = ["contract"]
 contract = []
-data-driver = []
+data-driver = ["dep:dusk-data-driver"]
 
 [dependencies]
 dusk-forge = { path = "../../../" }
+dusk-data-driver = { version = "0.3", optional = true }

--- a/contract-macro/tests/compile-pass/src/data_driver/mod.rs
+++ b/contract-macro/tests/compile-pass/src/data_driver/mod.rs
@@ -1,0 +1,5 @@
+pub mod module_local_const;
+pub mod module_local_impl_only_use;
+pub mod module_local_private_type_alias;
+pub mod module_local_struct_field;
+pub mod module_local_type_alias;

--- a/contract-macro/tests/compile-pass/src/data_driver/module_local_const.rs
+++ b/contract-macro/tests/compile-pass/src/data_driver/module_local_const.rs
@@ -1,0 +1,22 @@
+// Pins: generate::contract_module::module_local_const_generic
+//
+// Module-local `const` as a const-generic argument in a public signature under
+// the `data-driver` feature (forge#36). Resolves `DEPTH` in `[u8; DEPTH]` and
+// compiles the const in the data-visible module copy.
+
+#[dusk_forge::contract]
+pub mod my_contract {
+    const DEPTH: usize = 8;
+
+    pub struct MyContract;
+
+    impl MyContract {
+        pub const fn new() -> Self {
+            Self
+        }
+
+        pub fn depth_bytes(&self) -> [u8; DEPTH] {
+            [0; DEPTH]
+        }
+    }
+}

--- a/contract-macro/tests/compile-pass/src/data_driver/module_local_impl_only_use.rs
+++ b/contract-macro/tests/compile-pass/src/data_driver/module_local_impl_only_use.rs
@@ -1,0 +1,34 @@
+// Pins: generate::data_visible_items::skips_impl_only_use
+//
+// `use` lines referenced only from impl bodies must not appear in the
+// data-visible module (forge#36). Including `use only_impl::abi_helper` would
+// fail because `only_impl` is not copied into that cfg branch.
+
+#[dusk_forge::contract]
+pub mod my_contract {
+    mod only_impl {
+        pub fn abi_helper() -> u32 {
+            42
+        }
+    }
+
+    use only_impl::abi_helper;
+
+    const DEPTH: usize = 8;
+
+    pub struct MyContract;
+
+    impl MyContract {
+        pub const fn new() -> Self {
+            Self
+        }
+
+        pub fn touch_impl_only_use(&mut self) {
+            let _ = abi_helper();
+        }
+
+        pub fn depth_bytes(&self) -> [u8; DEPTH] {
+            [0; DEPTH]
+        }
+    }
+}

--- a/contract-macro/tests/compile-pass/src/data_driver/module_local_private_type_alias.rs
+++ b/contract-macro/tests/compile-pass/src/data_driver/module_local_private_type_alias.rs
@@ -1,0 +1,22 @@
+// Pins: generate::contract_module::module_local_type_alias
+//
+// Private module-local type alias in a public method signature (forge#36).
+
+#[dusk_forge::contract]
+pub mod my_contract {
+    type Byte = u8;
+
+    const DEPTH: usize = 6;
+
+    pub struct MyContract;
+
+    impl MyContract {
+        pub const fn new() -> Self {
+            Self
+        }
+
+        pub fn depth_bytes(&self) -> [Byte; DEPTH] {
+            [0; DEPTH]
+        }
+    }
+}

--- a/contract-macro/tests/compile-pass/src/data_driver/module_local_struct_field.rs
+++ b/contract-macro/tests/compile-pass/src/data_driver/module_local_struct_field.rs
@@ -1,0 +1,22 @@
+// Pins: generate::contract_module::module_local_const_generic
+//
+// Struct field type uses a module-local `const` as array length (forge#36).
+
+#[dusk_forge::contract]
+pub mod my_contract {
+    const DEPTH: usize = 4;
+
+    pub struct MyContract {
+        buf: [u8; DEPTH],
+    }
+
+    impl MyContract {
+        pub const fn new() -> Self {
+            Self { buf: [0; DEPTH] }
+        }
+
+        pub fn buf(&self) -> &[u8; DEPTH] {
+            &self.buf
+        }
+    }
+}

--- a/contract-macro/tests/compile-pass/src/data_driver/module_local_type_alias.rs
+++ b/contract-macro/tests/compile-pass/src/data_driver/module_local_type_alias.rs
@@ -1,0 +1,22 @@
+// Pins: generate::contract_module::module_local_const_generic
+//
+// `pub type` alias whose definition uses a module-local `const` (forge#36).
+
+#[dusk_forge::contract]
+pub mod my_contract {
+    const DEPTH: usize = 12;
+
+    pub type DepthBuf = [u8; DEPTH];
+
+    pub struct MyContract;
+
+    impl MyContract {
+        pub const fn new() -> Self {
+            Self
+        }
+
+        pub fn depth_buf(&self) -> DepthBuf {
+            [0; DEPTH]
+        }
+    }
+}

--- a/contract-macro/tests/compile-pass/src/lib.rs
+++ b/contract-macro/tests/compile-pass/src/lib.rs
@@ -6,5 +6,10 @@
 
 #![no_std]
 
+#[cfg(feature = "contract")]
 pub mod events;
+#[cfg(feature = "contract")]
 pub mod methods;
+
+#[cfg(feature = "data-driver")]
+pub mod data_driver;

--- a/contract-macro/tests/compile_pass.rs
+++ b/contract-macro/tests/compile_pass.rs
@@ -27,3 +27,23 @@ fn compile_pass_tests() {
         String::from_utf8_lossy(&output.stderr),
     );
 }
+
+#[test]
+fn compile_pass_data_driver_tests() {
+    let output = std::process::Command::new("cargo")
+        .arg("check")
+        .arg("--all-targets")
+        .arg("--no-default-features")
+        .arg("--features")
+        .arg("data-driver")
+        .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/compile-pass"))
+        .output()
+        .expect("failed to run cargo check");
+
+    assert!(
+        output.status.success(),
+        "compile-pass data-driver fixtures failed to build:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}


### PR DESCRIPTION
## Summary

Closes #36 — `data-driver` builds failed when a `#[contract]` module used a module-local `const` as a const-generic parameter (e.g. Merkle depth in a return type). The annotated module was fully cfg-gated away under `data-driver`, and const-generic paths were not resolved/brace-wrapped for sibling codegen.

- Under `data-driver`, keep plain data items (const/struct/enum/type + needed `use`s) in a second cfg-gated copy of the contract module.
- Feed module-local items into the type map; brace-wrap consts for generic args.
- Resolve const idents in array lengths and const-generic parameters in `resolve.rs`.
- Regression: five `data_driver/` compile-pass fixtures plus four unit tests in `generate.rs` / `resolve.rs`.

## Test plan

Five compile-pass fixtures under `tests/compile-pass/src/data_driver/` (run via `compile_pass_data_driver_tests` with `--no-default-features --features data-driver` only — contract-default fixtures are intentionally excluded). Four unit tests in `generate.rs` / `resolve.rs` cover type-map and resolution helpers without a full macro expand.

**New regression**

| Fixture / test | What it checks |
|----------------|----------------|
| `module_local_const` | Private module-local `const DEPTH` compiles under `data-driver`; return type `[u8; DEPTH]` resolves and type-checks |
| `module_local_type_alias` | Same const in a `pub type DepthBuf = [u8; DEPTH]` used as return type |
| `module_local_struct_field` | Const-generic depth in a **struct field** type (`buf: [u8; DEPTH]`), not only in method signatures |
| `module_local_private_type_alias` | Private `type Byte = u8` in signature `[Byte; DEPTH]` — visibility bump on re-emitted type aliases |
| `module_local_impl_only_use` | `use` only referenced from impl body is **not** copied into data-visible module (would break compile if included) |
| `test_local_const_imports_brace_wraps_const` | `local_const_imports` maps `DEPTH` → `{ super::mod::DEPTH }` for const-generic splice |
| `test_data_visible_items_skips_impl_only_use` | `data_visible_items` filters impl-only `use` without a full macro expand |
| `test_resolve_array_length_const_import` | `resolve_type` on `[u8; DEPTH]` substitutes imported const path |
| `test_resolve_const_generic_argument` | `resolve_type` on `Opening<DEPTH>` substitutes const generic arg |
| `compile_pass_data_driver_tests` | Harness: entire `data_driver/` fixture tree with `--no-default-features --features data-driver` |

**Run:**

```bash
cargo test -p dusk-forge-contract
```

- `compile_pass_tests` — existing contract-default compile-pass sub-crate (`default = ["contract"]`)
- `compile_pass_data_driver_tests` — `data_driver/` fixtures only (`--no-default-features --features data-driver`)
- `compile_fail` + `generate` / `resolve` unit tests — unchanged; new rows in table above

### `missing_feature_gate.stderr`

Blessed trybuild expected output for `tests/compile-fail/feature_gates/missing_feature_gate.rs` — not a behavior change. Rustc no longer emits the `dusk_forge_contract` “old version” help line on `unexpected_cfgs` warnings; the snapshot was updated to match local `cargo test -p dusk-forge-contract -test compile_fail` output.  The pinned rule (`generate::feature_gate::missing`) and the `compile_error!` message are unchanged.
