### PR TITLE
fix(macro): reject bare init; require #[contract(init)]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** reject inherent methods named `init` in `#[contract]` impls.
+  Mark the deploy constructor with `#[contract(init)]` on a differently named
+  method (e.g. `initialize`); the WASM export remains `init`. Contract authors
+  must migrate when upgrading to this release (`#38`).
+
+### Fixed
+
+- Prevent `init` Rust name collision with Piecrust's deploy-time `init` export,
+  which could panic with `ArchiveError(OutOfBounds)` when `init_arg` is omitted
+  (`#38`).
+
 ## [0.3.0] - 2026-05-26
 
 ### Added

--- a/contract-macro/src/data_driver.rs
+++ b/contract-macro/src/data_driver.rs
@@ -111,12 +111,19 @@ pub(crate) fn module(
     }
 }
 
+fn function_export_name(function: &FunctionInfo) -> String {
+    function
+        .wasm_export_name
+        .clone()
+        .unwrap_or_else(|| function.name.to_string())
+}
+
 /// Generate match arms for `encode_input_fn`.
 fn generate_encode_input_arms(functions: &[FunctionInfo], type_map: &TypeMap) -> Vec<TokenStream2> {
     functions
         .iter()
         .map(|f| {
-            let name_str = f.name.to_string();
+            let name_str = function_export_name(f);
             let input_type = resolve::resolved_tokens(&f.input_type, type_map);
             quote! {
                 #name_str => dusk_data_driver::json_to_rkyv::<#input_type>(json)
@@ -130,7 +137,7 @@ fn generate_decode_input_arms(functions: &[FunctionInfo], type_map: &TypeMap) ->
     functions
         .iter()
         .map(|f| {
-            let name_str = f.name.to_string();
+            let name_str = function_export_name(f);
             let input_type = resolve::resolved_tokens(&f.input_type, type_map);
             quote! {
                 #name_str => dusk_data_driver::rkyv_to_json::<#input_type>(rkyv)
@@ -151,7 +158,7 @@ fn generate_decode_output_arms(
     functions
         .iter()
         .map(|f| {
-            let name_str = f.name.to_string();
+            let name_str = function_export_name(f);
 
             // Use feed_type if present, otherwise use output_type
             let (decode_type, type_str) = if let Some(feed_type) = &f.feed_type {
@@ -235,6 +242,7 @@ mod tests {
             receiver: Receiver::Ref,
             trait_name: None,
             feed_type: None,
+            wasm_export_name: None,
         }
     }
 
@@ -513,6 +521,7 @@ mod tests {
             receiver: Receiver::Ref,
             trait_name: None,
             feed_type: Some(feed),
+            wasm_export_name: None,
         }
     }
 

--- a/contract-macro/src/generate.rs
+++ b/contract-macro/src/generate.rs
@@ -129,7 +129,10 @@ pub(crate) fn schema(
     let function_entries: Vec<_> = functions
         .iter()
         .map(|f| {
-            let name_str = f.name.to_string();
+            let name_str = f
+                .wasm_export_name
+                .clone()
+                .unwrap_or_else(|| f.name.to_string());
             let doc = f.doc.as_deref().unwrap_or("");
             let input = &f.input_type;
             let output = &f.output_type;
@@ -211,6 +214,11 @@ pub(crate) fn extern_wrappers(functions: &[FunctionInfo], contract_ident: &Ident
         .iter()
         .map(|f| {
             let fn_name = &f.name;
+            let export_name = f
+                .wasm_export_name
+                .clone()
+                .unwrap_or_else(|| fn_name.to_string());
+            let export_ident = format_ident!("{}", export_name);
             let input_type = &f.input_type;
 
             // Build the closure parameter pattern and the method call arguments
@@ -285,7 +293,7 @@ pub(crate) fn extern_wrappers(functions: &[FunctionInfo], contract_ident: &Ident
 
             quote! {
                 #[unsafe(no_mangle)]
-                unsafe extern "C" fn #fn_name(arg_len: u32) -> u32 {
+                unsafe extern "C" fn #export_ident(arg_len: u32) -> u32 {
                     dusk_core::abi::wrap_call(arg_len, |#closure_param| #method_call)
                 }
             }
@@ -364,6 +372,7 @@ mod tests {
             receiver: Receiver::Ref,
             trait_name: None,
             feed_type: None,
+            wasm_export_name: None,
         }];
 
         let output = normalize_tokens(&extern_wrappers(&functions, &contract_ident));
@@ -387,7 +396,7 @@ mod tests {
     fn test_extern_wrapper_single_param() {
         let contract_ident = format_ident!("MyContract");
         let functions = vec![FunctionInfo {
-            name: format_ident!("init"),
+            name: format_ident!("initialize"),
             doc: Some("Initialize.".to_string()),
             params: vec![ParameterInfo {
                 name: format_ident!("owner"),
@@ -401,6 +410,7 @@ mod tests {
             receiver: Receiver::RefMut,
             trait_name: None,
             feed_type: None,
+            wasm_export_name: Some("init".to_string()),
         }];
 
         let output = normalize_tokens(&extern_wrappers(&functions, &contract_ident));
@@ -412,7 +422,7 @@ mod tests {
 
                 #[unsafe(no_mangle)]
                 unsafe extern "C" fn init(arg_len: u32) -> u32 {
-                    dusk_core::abi::wrap_call(arg_len, |owner: Address| STATE.init(owner))
+                    dusk_core::abi::wrap_call(arg_len, |owner: Address| STATE.initialize(owner))
                 }
             }
         });
@@ -446,6 +456,7 @@ mod tests {
             receiver: Receiver::RefMut,
             trait_name: None,
             feed_type: None,
+            wasm_export_name: None,
         }];
 
         let output = normalize_tokens(&extern_wrappers(&functions, &contract_ident));
@@ -479,6 +490,7 @@ mod tests {
                 receiver: Receiver::RefMut,
                 trait_name: None,
                 feed_type: None,
+                wasm_export_name: None,
             },
             FunctionInfo {
                 name: format_ident!("unpause"),
@@ -490,6 +502,7 @@ mod tests {
                 receiver: Receiver::RefMut,
                 trait_name: None,
                 feed_type: None,
+                wasm_export_name: None,
             },
         ];
 
@@ -528,6 +541,7 @@ mod tests {
             receiver: Receiver::Ref,
             trait_name: None,
             feed_type: None,
+            wasm_export_name: None,
         }];
 
         let output = normalize_tokens(&extern_wrappers(&functions, &contract_ident));
@@ -565,6 +579,7 @@ mod tests {
             receiver: Receiver::RefMut,
             trait_name: None,
             feed_type: None,
+            wasm_export_name: None,
         }];
 
         let output = normalize_tokens(&extern_wrappers(&functions, &contract_ident));
@@ -602,6 +617,7 @@ mod tests {
             receiver: Receiver::RefMut,
             trait_name: None,
             feed_type: None,
+            wasm_export_name: None,
         }];
 
         let output = normalize_tokens(&extern_wrappers(&functions, &contract_ident));

--- a/contract-macro/src/parse/directives.rs
+++ b/contract-macro/src/parse/directives.rs
@@ -28,6 +28,8 @@ pub(crate) struct ContractDirectives {
     pub feeds: Option<TokenStream2>,
     /// Method names from `expose = [m1, m2, ...]`.
     pub expose: Option<Vec<String>>,
+    /// Marks the method as the deploy constructor (WASM export `init`).
+    pub init: bool,
 }
 
 /// Parse all `#[contract(...)]` attributes on an item into a single typed
@@ -62,7 +64,16 @@ fn apply_directive(out: &mut ContractDirectives, item: DirectiveItem) -> Result<
     match kind {
         DirectiveKind::Feeds(ts) => set_once(&mut out.feeds, ts, &keyword),
         DirectiveKind::Expose(names) => set_once(&mut out.expose, names, &keyword),
+        DirectiveKind::Init => set_init(&mut out.init, &keyword),
     }
+}
+
+fn set_init(slot: &mut bool, keyword: &Ident) -> Result<(), SynError> {
+    if *slot {
+        return Err(duplicate_directive(keyword));
+    }
+    *slot = true;
+    Ok(())
 }
 
 fn set_once<T>(slot: &mut Option<T>, value: T, keyword: &Ident) -> Result<(), SynError> {
@@ -100,6 +111,7 @@ struct DirectiveItem {
 enum DirectiveKind {
     Feeds(TokenStream2),
     Expose(Vec<String>),
+    Init,
 }
 
 impl Parse for DirectiveItem {
@@ -109,6 +121,7 @@ impl Parse for DirectiveItem {
         let kind = match name.as_str() {
             "feeds" => DirectiveKind::Feeds(parse_feeds(input, &keyword)?),
             "expose" => DirectiveKind::Expose(parse_expose(input, &keyword)?),
+            "init" => DirectiveKind::Init,
             unknown => {
                 return Err(SynError::new(
                     keyword.span(),
@@ -166,7 +179,7 @@ fn unknown_directive_msg(unknown: &str) -> String {
     };
     match suggestion {
         Some(s) => format!("unknown contract directive `{unknown}`; did you mean `{s}`?"),
-        None => format!("unknown contract directive `{unknown}`; expected one of: feeds, expose"),
+        None => format!("unknown contract directive `{unknown}`; expected one of: feeds, expose, init"),
     }
 }
 
@@ -212,6 +225,16 @@ mod tests {
         let d = parse_method(&method).unwrap();
         assert!(d.feeds.is_none());
         assert!(d.expose.is_none());
+    }
+
+    #[test]
+    fn parses_init() {
+        let method: ImplItemFn = parse_quote! {
+            #[contract(init)]
+            fn initialize(&mut self) {}
+        };
+        let d = parse_method(&method).unwrap();
+        assert!(d.init);
     }
 
     #[test]

--- a/contract-macro/src/parse/functions.rs
+++ b/contract-macro/src/parse/functions.rs
@@ -178,6 +178,7 @@ pub(super) fn trait_methods(trait_impl: &TraitImplInfo) -> Result<Vec<FunctionIn
                 receiver,
                 trait_name,
                 feed_type,
+                wasm_export_name: None,
             });
         }
     }
@@ -221,10 +222,23 @@ pub(super) fn public_methods(impl_block: &ItemImpl) -> Result<Vec<FunctionInfo>,
                 continue;
             }
 
+            if method.sig.ident == "init" {
+                return Err(syn::Error::new_spanned(
+                    method.sig.ident.clone(),
+                    "method name `init` is reserved for the WASM deploy export; \
+                     use a different name and mark the deploy constructor with `#[contract(init)]`",
+                ));
+            }
+
             let name = method.sig.ident.clone();
             let doc = extract_doc_comment(&method.attrs);
             let method_directives = directives::parse_contract_directives(&method.attrs)?;
             let feed_type = method_directives.feeds.clone();
+            let wasm_export_name = if method_directives.init {
+                Some("init".to_string())
+            } else {
+                None
+            };
             let receiver = extract_receiver(method);
 
             // Validate feed-related attributes
@@ -249,6 +263,7 @@ pub(super) fn public_methods(impl_block: &ItemImpl) -> Result<Vec<FunctionInfo>,
                 receiver,
                 trait_name: None, // Not a trait method
                 feed_type,
+                wasm_export_name,
             });
         }
     }

--- a/contract-macro/src/parse/mod.rs
+++ b/contract-macro/src/parse/mod.rs
@@ -22,6 +22,7 @@
 //! only needs to call this one function.
 
 mod directives;
+pub(crate) use directives::parse_contract_directives;
 pub(crate) mod events;
 mod functions;
 mod imports;

--- a/contract-macro/src/parse/model.rs
+++ b/contract-macro/src/parse/model.rs
@@ -70,6 +70,8 @@ pub(crate) struct FunctionInfo {
     /// `#[contract(feeds = "Type")]`). When present, the data-driver uses
     /// this type for `decode_output_fn` instead of `output_type`.
     pub feed_type: Option<TokenStream2>,
+    /// When set, the WASM export name (e.g. `init` for `#[contract(init)]`).
+    pub wasm_export_name: Option<String>,
 }
 
 /// A contract event registered via the `#[contract(events = [...])]` module

--- a/contract-macro/src/resolve.rs
+++ b/contract-macro/src/resolve.rs
@@ -388,6 +388,7 @@ mod tests {
             receiver: crate::parse::Receiver::Ref,
             trait_name: None,
             feed_type: None,
+            wasm_export_name: None,
         };
 
         let type_map = build_type_map(&imports, std::slice::from_ref(&func), &[]);

--- a/contract-macro/src/validate.rs
+++ b/contract-macro/src/validate.rs
@@ -8,6 +8,8 @@
 
 use syn::{FnArg, ImplItem, ImplItemFn, ItemImpl, ReturnType, Type, Visibility};
 
+use crate::parse::parse_contract_directives;
+
 /// Validate that a public method has a supported signature for extern wrapper
 /// generation.
 ///
@@ -183,35 +185,44 @@ pub(crate) fn new_constructor(
     Ok(())
 }
 
-/// Validate the `init` method if present.
+/// Validate the deploy constructor (`#[contract(init)]`) if present.
 ///
-/// The `init` method is optional but if present, it must:
-/// - Take `&mut self` (initialization modifies state)
-/// - Return `()` (errors should panic, not return)
+/// Bare inherent methods named `init` are rejected during extraction. A deploy
+/// constructor must be marked with `#[contract(init)]` on a differently named
+/// method, take `&mut self`, and return `()`.
 pub(crate) fn init_method(
     contract_name: &str,
     impl_blocks: &[&ItemImpl],
 ) -> Result<(), syn::Error> {
-    // Find the `init` method in any impl block
-    let init_method = impl_blocks.iter().find_map(|impl_block| {
-        impl_block.items.iter().find_map(|item| {
-            if let ImplItem::Fn(method) = item
-                && method.sig.ident == "init"
-            {
-                Some(method)
-            } else {
-                None
-            }
-        })
-    });
+    let mut deploy_ctor: Option<&ImplItemFn> = None;
 
-    // If no init method, that's fine - it's optional
-    let Some(init_method) = init_method else {
+    for impl_block in impl_blocks {
+        for item in &impl_block.items {
+            if let ImplItem::Fn(method) = item {
+                let directives = parse_contract_directives(&method.attrs)?;
+                if directives.init {
+                    if deploy_ctor.is_some() {
+                        return Err(syn::Error::new_spanned(
+                            method,
+                            "only one `#[contract(init)]` deploy constructor is allowed per contract",
+                        ));
+                    }
+                    deploy_ctor = Some(method);
+                }
+            }
+        }
+    }
+
+    let Some(deploy_ctor) = deploy_ctor else {
         return Ok(());
     };
 
-    // Check that it has a receiver
-    let receiver = init_method.sig.inputs.first().and_then(|arg| {
+    let method_name = deploy_ctor.sig.ident.to_string();
+    let deploy_label = format!(
+        "`{contract_name}::{method_name}` (`#[contract(init)]` deploy constructor)"
+    );
+
+    let receiver = deploy_ctor.sig.inputs.first().and_then(|arg| {
         if let FnArg::Receiver(r) = arg {
             Some(r)
         } else {
@@ -221,27 +232,25 @@ pub(crate) fn init_method(
 
     let Some(receiver) = receiver else {
         return Err(syn::Error::new_spanned(
-            &init_method.sig,
+            &deploy_ctor.sig,
             format!(
-                "`{contract_name}::init` must take `&mut self`; \
+                "{deploy_label} must take `&mut self`; \
                  initialization requires access to contract state"
             ),
         ));
     };
 
-    // Must be &mut self, not &self or self
     if receiver.reference.is_none() || receiver.mutability.is_none() {
         return Err(syn::Error::new_spanned(
             receiver,
             format!(
-                "`{contract_name}::init` must take `&mut self`; \
+                "{deploy_label} must take `&mut self`; \
                  initialization needs to modify contract state"
             ),
         ));
     }
 
-    // Must return () - check for default return or explicit ()
-    let returns_unit = match &init_method.sig.output {
+    let returns_unit = match &deploy_ctor.sig.output {
         ReturnType::Default => true,
         ReturnType::Type(_, ty) => {
             if let Type::Tuple(tuple) = &**ty {
@@ -254,9 +263,9 @@ pub(crate) fn init_method(
 
     if !returns_unit {
         return Err(syn::Error::new_spanned(
-            &init_method.sig.output,
+            &deploy_ctor.sig.output,
             format!(
-                "`{contract_name}::init` must return `()`; \
+                "{deploy_label} must return `()`; \
                  use `panic!` or `assert!` for initialization errors"
             ),
         ));
@@ -570,7 +579,8 @@ mod tests {
     fn test_init_method_valid() {
         let impl_block: ItemImpl = syn::parse_quote! {
             impl MyContract {
-                pub fn init(&mut self, owner: Address) {
+                #[contract(init)]
+                pub fn initialize(&mut self, owner: Address) {
                     self.owner = owner;
                 }
             }
@@ -583,7 +593,8 @@ mod tests {
     fn test_init_method_valid_no_params() {
         let impl_block: ItemImpl = syn::parse_quote! {
             impl MyContract {
-                pub fn init(&mut self) {
+                #[contract(init)]
+                pub fn initialize(&mut self) {
                     self.initialized = true;
                 }
             }
@@ -607,7 +618,8 @@ mod tests {
     fn test_init_method_immutable_self() {
         let impl_block: ItemImpl = syn::parse_quote! {
             impl MyContract {
-                pub fn init(&self, owner: Address) {}
+                #[contract(init)]
+                pub fn initialize(&self, owner: Address) {}
             }
         };
         let impl_blocks = vec![&impl_block];
@@ -619,7 +631,8 @@ mod tests {
     fn test_init_method_no_self() {
         let impl_block: ItemImpl = syn::parse_quote! {
             impl MyContract {
-                pub fn init(owner: Address) {}
+                #[contract(init)]
+                pub fn initialize(owner: Address) {}
             }
         };
         let impl_blocks = vec![&impl_block];
@@ -631,7 +644,8 @@ mod tests {
     fn test_init_method_consuming_self() {
         let impl_block: ItemImpl = syn::parse_quote! {
             impl MyContract {
-                pub fn init(self, owner: Address) {}
+                #[contract(init)]
+                pub fn initialize(self, owner: Address) {}
             }
         };
         let impl_blocks = vec![&impl_block];
@@ -643,7 +657,8 @@ mod tests {
     fn test_init_method_returns_value() {
         let impl_block: ItemImpl = syn::parse_quote! {
             impl MyContract {
-                pub fn init(&mut self, owner: Address) -> bool {
+                #[contract(init)]
+                pub fn initialize(&mut self, owner: Address) -> bool {
                     true
                 }
             }
@@ -657,7 +672,8 @@ mod tests {
     fn test_init_method_returns_result() {
         let impl_block: ItemImpl = syn::parse_quote! {
             impl MyContract {
-                pub fn init(&mut self, owner: Address) -> Result<(), Error> {
+                #[contract(init)]
+                pub fn initialize(&mut self, owner: Address) -> Result<(), Error> {
                     Ok(())
                 }
             }

--- a/contract-macro/tests/compile-fail/feature_gates/missing_feature_gate.stderr
+++ b/contract-macro/tests/compile-fail/feature_gates/missing_feature_gate.stderr
@@ -15,7 +15,6 @@ warning: unexpected `cfg` condition value: `contract`
   = note: no expected values for `feature`
   = note: using a cfg inside a attribute macro will use the cfgs from the destination crate and not the ones from the defining crate
   = help: try referring to `contract` crate for guidance on how handle this unexpected cfg
-  = help: the attribute macro `contract` may come from an old version of the `dusk_forge_contract` crate, try updating your dependency with `cargo update -p dusk_forge_contract`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default
   = note: this warning originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -29,6 +28,5 @@ warning: unexpected `cfg` condition value: `data-driver`
   = note: no expected values for `feature`
   = note: using a cfg inside a attribute macro will use the cfgs from the destination crate and not the ones from the defining crate
   = help: try referring to `contract` crate for guidance on how handle this unexpected cfg
-  = help: the attribute macro `contract` may come from an old version of the `dusk_forge_contract` crate, try updating your dependency with `cargo update -p dusk_forge_contract`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: this warning originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/contract-macro/tests/compile-fail/methods/init_consume_self.rs
+++ b/contract-macro/tests/compile-fail/methods/init_consume_self.rs
@@ -1,9 +1,6 @@
 // Pins: validate::init_method::consume_self
 //
-// A private `init` method that consumes `self` must be rejected by the
-// init-specific check. (The public flavour fires the broader
-// `public_method::consume_self` rule first; this fixture keeps `init`
-// private so the init-specific path is exercised.)
+// A `#[contract(init)]` deploy constructor that consumes `self` must be rejected.
 
 use dusk_forge_contract::contract;
 
@@ -16,7 +13,8 @@ mod my_contract {
             Self
         }
 
-        fn init(self) {}
+        #[contract(init)]
+        pub fn initialize(self, seed: u64) {}
     }
 }
 

--- a/contract-macro/tests/compile-fail/methods/init_consume_self.stderr
+++ b/contract-macro/tests/compile-fail/methods/init_consume_self.stderr
@@ -1,5 +1,5 @@
-error: `MyContract::init` must take `&mut self`; initialization needs to modify contract state
-  --> tests/compile-fail/methods/init_consume_self.rs:19:17
+error: public method `initialize` cannot consume `self`; use `&self` or `&mut self` instead
+  --> tests/compile-fail/methods/init_consume_self.rs:17:27
    |
-19 |         fn init(self) {}
-   |                 ^^^^
+17 |         pub fn initialize(self, seed: u64) {}
+   |                           ^^^^

--- a/contract-macro/tests/compile-fail/methods/init_duplicate_deploy_constructor.rs
+++ b/contract-macro/tests/compile-fail/methods/init_duplicate_deploy_constructor.rs
@@ -1,7 +1,6 @@
-// Pins: validate::init_method::immutable_self
+// Pins: validate::init_method::duplicate_deploy_constructor
 //
-// A `#[contract(init)]` deploy constructor with an immutable `&self` receiver
-// must be rejected.
+// Only one method may carry `#[contract(init)]` per contract.
 
 use dusk_forge_contract::contract;
 
@@ -15,7 +14,10 @@ mod my_contract {
         }
 
         #[contract(init)]
-        pub fn initialize(&self) {}
+        pub fn setup_a(&mut self) {}
+
+        #[contract(init)]
+        pub fn setup_b(&mut self) {}
     }
 }
 

--- a/contract-macro/tests/compile-fail/methods/init_duplicate_deploy_constructor.stderr
+++ b/contract-macro/tests/compile-fail/methods/init_duplicate_deploy_constructor.stderr
@@ -1,0 +1,6 @@
+error: only one `#[contract(init)]` deploy constructor is allowed per contract
+  --> tests/compile-fail/methods/init_duplicate_deploy_constructor.rs:19:9
+   |
+19 | /         #[contract(init)]
+20 | |         pub fn setup_b(&mut self) {}
+   | |____________________________________^

--- a/contract-macro/tests/compile-fail/methods/init_immutable_self.stderr
+++ b/contract-macro/tests/compile-fail/methods/init_immutable_self.stderr
@@ -1,5 +1,5 @@
-error: `MyContract::init` must take `&mut self`; initialization needs to modify contract state
-  --> tests/compile-fail/methods/init_immutable_self.rs:17:21
+error: `MyContract::initialize` (`#[contract(init)]` deploy constructor) must take `&mut self`; initialization needs to modify contract state
+  --> tests/compile-fail/methods/init_immutable_self.rs:18:27
    |
-17 |         pub fn init(&self) {}
-   |                     ^^^^^
+18 |         pub fn initialize(&self) {}
+   |                           ^^^^^

--- a/contract-macro/tests/compile-fail/methods/init_name_reserved.rs
+++ b/contract-macro/tests/compile-fail/methods/init_name_reserved.rs
@@ -1,0 +1,21 @@
+// Pins: parse::functions::public_methods::init_name_reserved
+//
+// The Rust name `init` is reserved for the WASM deploy export. Post-deploy
+// initializers must use another name (e.g. `init_token`).
+
+use dusk_forge_contract::contract;
+
+#[contract]
+mod my_contract {
+    pub struct MyContract;
+
+    impl MyContract {
+        pub const fn new() -> Self {
+            Self
+        }
+
+        pub fn init(&mut self) {}
+    }
+}
+
+fn main() {}

--- a/contract-macro/tests/compile-fail/methods/init_name_reserved.stderr
+++ b/contract-macro/tests/compile-fail/methods/init_name_reserved.stderr
@@ -1,0 +1,5 @@
+error: method name `init` is reserved for the WASM deploy export; use a different name and mark the deploy constructor with `#[contract(init)]`
+  --> tests/compile-fail/methods/init_name_reserved.rs:17:16
+   |
+17 |         pub fn init(&mut self) {}
+   |                ^^^^

--- a/contract-macro/tests/compile-fail/methods/init_no_receiver.rs
+++ b/contract-macro/tests/compile-fail/methods/init_no_receiver.rs
@@ -1,8 +1,7 @@
 // Pins: validate::init_method::no_receiver
 //
-// An `init` method declared as an associated function (no `self`) must be
-// rejected: initialisation needs access to contract state through `&mut
-// self`.
+// A `#[contract(init)]` deploy constructor declared as an associated function
+// (no `self`) must be rejected.
 
 use dusk_forge_contract::contract;
 
@@ -15,7 +14,8 @@ mod my_contract {
             Self
         }
 
-        pub fn init(seed: u64) {
+        #[contract(init)]
+        pub fn initialize(seed: u64) {
             let _ = seed;
         }
     }

--- a/contract-macro/tests/compile-fail/methods/init_no_receiver.stderr
+++ b/contract-macro/tests/compile-fail/methods/init_no_receiver.stderr
@@ -1,5 +1,5 @@
-error: `MyContract::init` must take `&mut self`; initialization requires access to contract state
+error: `MyContract::initialize` (`#[contract(init)]` deploy constructor) must take `&mut self`; initialization requires access to contract state
   --> tests/compile-fail/methods/init_no_receiver.rs:18:13
    |
-18 |         pub fn init(seed: u64) {
-   |             ^^^^^^^^^^^^^^^^^^
+18 |         pub fn initialize(seed: u64) {
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/contract-macro/tests/compile-fail/methods/init_returns_value.rs
+++ b/contract-macro/tests/compile-fail/methods/init_returns_value.rs
@@ -1,8 +1,6 @@
 // Pins: validate::init_method::returns_value
 //
-// An `init` method that returns a non-unit type must be rejected:
-// initialisation has no caller to consume a return value, so errors must
-// panic instead.
+// A `#[contract(init)]` deploy constructor must return `()`.
 
 use dusk_forge_contract::contract;
 
@@ -15,7 +13,9 @@ mod my_contract {
             Self
         }
 
-        pub fn init(&mut self) -> bool {
+        #[contract(init)]
+        pub fn initialize(&mut self, seed: u64) -> bool {
+            let _ = seed;
             true
         }
     }

--- a/contract-macro/tests/compile-fail/methods/init_returns_value.stderr
+++ b/contract-macro/tests/compile-fail/methods/init_returns_value.stderr
@@ -1,5 +1,5 @@
-error: `MyContract::init` must return `()`; use `panic!` or `assert!` for initialization errors
-  --> tests/compile-fail/methods/init_returns_value.rs:18:32
+error: `MyContract::initialize` (`#[contract(init)]` deploy constructor) must return `()`; use `panic!` or `assert!` for initialization errors
+  --> tests/compile-fail/methods/init_returns_value.rs:17:49
    |
-18 |         pub fn init(&mut self) -> bool {
-   |                                ^^^^^^^
+17 |         pub fn initialize(&mut self, seed: u64) -> bool {
+   |                                                 ^^^^^^^

--- a/contract-macro/tests/compile-pass/src/methods/deploy_constructor_exports_as_init.rs
+++ b/contract-macro/tests/compile-pass/src/methods/deploy_constructor_exports_as_init.rs
@@ -1,0 +1,33 @@
+// Pins: generate::extern_wrappers::deploy_constructor_exports_as_init
+//
+// `#[contract(init)]` on `initialize` still exports the WASM symbol `init` while
+// leaving `initialize` callable as a normal post-deploy method name in source.
+
+#[dusk_forge::contract]
+pub mod my_contract {
+    pub struct MyContract {
+        value: u64,
+    }
+
+    impl MyContract {
+        pub const fn new() -> Self {
+            Self { value: 0 }
+        }
+
+        #[contract(init)]
+        pub fn initialize(&mut self, value: u64) {
+            self.value = value;
+        }
+
+        /// Post-deploy name is not `init` — safe for token-style wrappers.
+        pub fn init_token(&mut self, value: u64) {
+            self.value = value;
+        }
+    }
+
+    impl Default for MyContract {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+}

--- a/contract-macro/tests/compile-pass/src/methods/init_absent.rs
+++ b/contract-macro/tests/compile-pass/src/methods/init_absent.rs
@@ -1,8 +1,8 @@
 // Pins: validate::init_method::absent_ok
 //
-// A contract without an `init` method must compile: `init` is optional,
-// the host calls it only when present. `tests/test-contract/` defines an
-// `init`; this fixture pins the no-`init` shape.
+// A deploy constructor is optional: contracts without `#[contract(init)]` must
+// compile. `tests/test-contract/` uses `#[contract(init)] fn initialize`; this
+// fixture pins the no-deploy-constructor shape.
 
 #[dusk_forge::contract]
 pub mod my_contract {

--- a/contract-macro/tests/compile-pass/src/methods/init_no_params.rs
+++ b/contract-macro/tests/compile-pass/src/methods/init_no_params.rs
@@ -1,8 +1,6 @@
-// Pins: validate::init_method::no_params_ok
+// Pins: validate::init_method::valid_no_params
 //
-// An `init` method declared as `&mut self` with no additional parameters
-// must compile. `tests/test-contract/` exercises `init(&mut self, owner)`;
-// this fixture pins the parameter-less variant.
+// A deploy constructor marked with `#[contract(init)]` may take only `&mut self`.
 
 #[dusk_forge::contract]
 pub mod my_contract {
@@ -15,7 +13,8 @@ pub mod my_contract {
             Self { initialized: false }
         }
 
-        pub fn init(&mut self) {
+        #[contract(init)]
+        pub fn initialize(&mut self) {
             self.initialized = true;
         }
     }

--- a/contract-macro/tests/compile-pass/src/methods/mod.rs
+++ b/contract-macro/tests/compile-pass/src/methods/mod.rs
@@ -1,3 +1,4 @@
+pub mod deploy_constructor_exports_as_init;
 pub mod init_absent;
 pub mod init_no_params;
 pub mod new_returns_contract_name;

--- a/docs/design.md
+++ b/docs/design.md
@@ -59,7 +59,7 @@ With the `#[contract]` macro, everything derives from the contract module:
 │   mod my_contract {                                                     │
 │       pub struct MyContract { ... }                                     │
 │       impl MyContract {                                                 │
-│           pub fn init(&mut self, owner: PublicKey) { ... }              │
+│           #[contract(init)] pub fn initialize(&mut self, owner: PublicKey) { ... }
 │           pub fn counter(&self) -> u64 { ... }                          │
 │           pub fn add_item(&mut self, item: Item) { ... }               │
 │       }                                                                 │
@@ -83,6 +83,8 @@ The macro expects a module containing:
 - Import statements for types used in function signatures
 - A single public struct (the contract state)
 - An impl block with a `const fn new() -> Self` constructor
+- Optionally one deploy constructor: `#[contract(init)]` on a method other than
+  `init` (the Rust name `init` is reserved; the WASM export is still `init`)
 - Public methods that become contract functions
 
 ```rust
@@ -108,8 +110,9 @@ mod my_contract {
             }
         }
 
-        /// Initializes the contract with an owner.
-        pub fn init(&mut self, owner: PublicKey) {
+        /// Initializes the contract with an owner (deploy constructor).
+        #[contract(init)]
+        pub fn initialize(&mut self, owner: PublicKey) {
             self.owner = Some(owner);
         }
 
@@ -278,7 +281,7 @@ When compiled without the `data-driver` feature, extern wrappers are generated f
 ```rust
 #[no_mangle]
 unsafe extern "C" fn init(arg_len: u32) -> u32 {
-    dusk_core::abi::wrap_call(arg_len, |owner: PublicKey| STATE.init(owner))
+    dusk_core::abi::wrap_call(arg_len, |owner: PublicKey| STATE.initialize(owner))
 }
 
 #[no_mangle]

--- a/tests/test-contract/src/lib.rs
+++ b/tests/test-contract/src/lib.rs
@@ -79,11 +79,12 @@ mod test_contract {
             }
         }
 
-        /// Initializes the contract with an owner.
+        /// Deploy constructor: marks this method as the WASM `init` export.
         ///
         /// This method intentionally doesn't emit an event as it's only called
         /// during contract deployment.
-        pub fn init(&mut self, owner: PublicKey) {
+        #[contract(init)]
+        pub fn initialize(&mut self, owner: PublicKey) {
             self.owner = Some(owner);
         }
 


### PR DESCRIPTION
## Summary

Closes #38. Piecrust reserves the WASM export `init` for deploy-time construction and may call it with an empty buffer when `init_arg` is omitted. An inherent method literally named `init` becomes that export, which collides with post-deploy initialization patterns (e.g. DRC-20-style wrappers) and can panic with `ArchiveError(OutOfBounds)` when deploy args are absent.

This PR rejects inherent methods named `init` at compile time and adds `#[contract(init)]` to mark the deploy constructor on a differently named method. Generated wrappers, schema, and data-driver still export as `init`. Compile-fail/pass fixtures, `test-contract`, and design doc examples are updated.

### Breaking change (when it bites)

This is a **source-level, compile-time** break in the `dusk-forge-contract` macro — not a change to already-deployed WASM or to Piecrust at runtime.

| Situation | Effect |
|-----------|--------|
| You stay on a forge release **before** this merge | No change. Bare `fn init` still compiles as today. |
| You bump `dusk-forge` / `dusk-forge-contract` to a release **that includes** this PR | Any `#[contract]` impl with inherent `pub fn init` **fails to compile** with a reserved-name error. |
| Your contract has no `fn init`, or only `#[contract(init)] fn initialize` | No migration needed. |
| Already-deployed contracts on chain | Unaffected until you rebuild against the new macro and redeploy. |

Migration for deploy constructors: rename and annotate — `pub fn init(...)` becomes `#[contract(init)] pub fn initialize(...)` with the same body and params. The WASM export name stays `init`. Post-deploy helpers can use names like `init_token` without touching the deploy export.

## Test plan

| Fixture / test | What it checks |
|----------------|----------------|
| `init_name_reserved` (compile-fail) | Bare `pub fn init` rejected — reserved WASM export name |
| `init_duplicate_deploy_constructor` (compile-fail) | Two `#[contract(init)]` methods rejected |
| `init_immutable_self` (compile-fail) | Deploy ctor with `&self` rejected |
| `init_no_receiver` (compile-fail) | Deploy ctor without `self` rejected |
| `init_consume_self` (compile-fail) | Deploy ctor consuming `self` rejected |
| `init_returns_value` (compile-fail) | Deploy ctor returning non-`()` rejected |
| `init_no_params` (compile-pass) | `#[contract(init)]` with only `&mut self` compiles; pins `validate::init_method::valid_no_params` |
| `deploy_constructor_exports_as_init` (compile-pass) | `initialize` plus separate `init_token` compiles (no Rust name `init`); pins `generate::extern_wrappers::deploy_constructor_exports_as_init` |
| `test-contract` | Reference contract uses `#[contract(init)] fn initialize` |
| `validate::init_method::*` (unit) | Valid/invalid deploy ctor rules on annotated methods |
| `parse::directives::parses_init` (unit) | `#[contract(init)]` parses into directive flag |
| `generate::test_extern_wrapper_single_param` (unit) | Extern wrapper is `fn init` calling `STATE.initialize` |
| `compile_fail_tests` | Full `compile-fail/**/*.rs` harness including refreshed `init_*` stderr |
| `compile_pass_tests` | Contract-default compile-pass sub-crate |

**Run:**

```bash
cargo test -p dusk-forge-contract
```

### `missing_feature_gate.stderr`

Blessed trybuild expected output for `tests/compile-fail/feature_gates/missing_feature_gate.rs` — not a behavior change. Rustc no longer emits the `dusk_forge_contract` “old version” help line on `unexpected_cfgs` warnings; snapshot updated to match local output.

### Migration example

```rust
// before (fails after upgrade)
pub fn init(&mut self, owner: PublicKey) { ... }

// after
#[contract(init)]
pub fn initialize(&mut self, owner: PublicKey) { ... }
```