### PR TITLE
docs: overflow-checks profile inheritance for vendored builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Document `[profile.release] overflow-checks` inheritance for vendored contract
+  builds, workspace layout, and VM-boundary panic debugging (README,
+  `contract-template/Cargo.toml` comment).
+
 ## [0.3.0] - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ make help      # Show all available targets
 
 The contract WASM will be at `target/contract/wasm32-unknown-unknown/release/my_contract.wasm`
 
-> **Note:** The template enables `overflow-checks = true` in release builds. This is critical for contract security - never disable it.
+> **Note:** The template sets `overflow-checks = true` in `[profile.release]`. That applies to **your contract and every dependency** in the WASM artifact. Keep it for contracts built on this template. If you **vendor third-party contract source**, read [Overflow Checks](#overflow-checks) — profile inheritance can differ from what upstream tested.
 
 ## Contract Structure
 
@@ -276,14 +276,40 @@ If a dependency has types used in function signatures, also add `name/serde` to 
 
 ### Overflow Checks
 
-Always enable overflow checks for contract safety:
+The contract template enables overflow checks in release builds:
 
 ```toml
 [profile.release]
 overflow-checks = true
 ```
 
-This prevents integer overflow vulnerabilities. The contract template includes this by default - never remove it.
+#### Default (forge-native contracts)
+
+Integer overflow in contract logic is a common vulnerability class. For contracts you develop **on this template**, keep overflow checks enabled in release.
+
+#### Profile inheritance
+
+`[profile.release]` in your `Cargo.toml` is not scoped to your crate alone. Cargo applies the same release profile settings to **every dependency** compiled into the contract WASM — not only the top-level contract crate.
+
+A dependency tested on crates.io under the default release profile may behave differently when compiled as part of your WASM build.
+
+#### Workspaces
+
+If the contract lives in a Cargo **workspace**, `[profile.release]` must be on the **workspace root** `Cargo.toml`. A member-only `[profile.release]` is ignored (Cargo warns: profiles for the non-root package will be ignored).
+
+#### Vendoring third-party contract source
+
+If you embed contract source from another project instead of depending on a published crate:
+
+- Read **both** Cargo trees — scaffold and upstream — not just one.
+- Upstream may never set `overflow-checks`; this template may force it on the whole WASM build.
+- Panics like `attempt to subtract with overflow` in `VM::ephemeral()` tests often originate inside a dependency; the host backtrace points at the test harness, not upstream source lines.
+
+Prefer published crates when possible. When vendoring source, align profiles deliberately with what upstream tested, or address dependency behavior under this profile upstream.
+
+#### Disabling overflow checks
+
+Only for a **deliberate, documented** reason (e.g. matching an upstream vendored project's known-tested profile). This weakens arithmetic safety for your code and dependencies. Do not remove the setting silently.
 
 ## Makefile Targets
 

--- a/contract-template/Cargo.toml
+++ b/contract-template/Cargo.toml
@@ -77,6 +77,7 @@ data-driver-js = ["data-driver", "dusk-data-driver/alloc"]
 [lib]
 crate-type = ["cdylib"]
 
-# Enable overflow checks in release builds for safety
+# Release profile for contract WASM. overflow-checks applies to this crate AND
+# every dependency Cargo compiles into the same WASM artifact.
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
## Summary

Addresses #41. Document how `[profile.release] overflow-checks = true` in the contract template applies to the **entire WASM dependency tree**, not only the top-level contract crate.

- Expand README **Overflow Checks**: inheritance, workspace root profile, vendoring third-party contract source, VM-boundary panic debugging.
- Adjust Quick Start note: recommend overflow checks for template-native work; vendoring caveat with link to Overflow Checks.
- Comment in `contract-template/Cargo.toml` that release profile settings affect dependencies.

**No change** to default `overflow-checks = true` setting. This PR only documents inheritance and vendoring implications and doesn't add new automated tests.

Related: [citadel#147](https://github.com/dusk-network/citadel/issues/147), [merkle#117](https://github.com/dusk-network/merkle/issues/117), [rusk#4066](https://github.com/dusk-network/rusk/issues/4066).